### PR TITLE
Prevent algoliasearch from throwing exceptions if some of the search results aren't returned locally

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -204,9 +204,11 @@ module AlgoliaSearch
       json = @algolia_index.search(q, Hash[settings.map { |k,v| [k.to_s, v.to_s] }])
       results = json['hits'].map do |hit|
         o = @algolia_options[:type].where(algolia_object_id_method => hit['objectID']).first
-        o.highlight_result = hit['_highlightResult']
-        o
-      end
+        if o
+          o.highlight_result = hit['_highlightResult']
+          o
+        end
+      end.compact
       AlgoliaSearch::Pagination.create(results, json['nbHits'].to_i, @algolia_options)
     end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -394,6 +394,16 @@ describe 'An imaginary store' do
       results.should have_exactly(0).product
     end
 
+    it "should not throw an exception if a search result isn't found locally" do
+      Product.without_auto_index { @palmpre.destroy }
+      expect { Product.search('pal').to_json }.to_not raise_error
+    end
+
+    it 'should return the other results if those are still available locally' do
+      Product.without_auto_index { @palmpre.destroy }
+      JSON.parse(Product.search('pal').to_json).size.should == 1
+    end
+
     it "should not duplicate an already indexed record" do
       Product.search('nokia').should have_exactly(1).product
       @nokia.index!


### PR DESCRIPTION
In some cases, we're applying various scopes to the algoliasearch results.  When those filter out results that are returned from the search backend, then it throws an exception trying to highlight results.  This ensures that those results are just filtered out instead.
