### PR TITLE
Fixes searches on Mongoid as broken by commit 003cdec / #21.

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -357,7 +357,12 @@ module AlgoliaSearch
       end
       json = algolia_raw_search(q, params)
       hit_ids = json['hits'].map { |hit| hit['objectID'] }
-      results_by_id = algoliasearch_options[:type].where(algolia_object_id_method => hit_ids).index_by do |hit|
+      if defined?(::Mongoid::Document) && self.include?(::Mongoid::Document)
+        condition_key = algolia_object_id_method.in
+      else
+        condition_key = algolia_object_id_method
+      end
+      results_by_id = algoliasearch_options[:type].where(condition_key => hit_ids).index_by do |hit|
         algolia_object_id_of(hit)
       end
       results = json['hits'].map do |hit|


### PR DESCRIPTION
The API for where() when querying for multiple IDs differs between ActiveRecord and Mongoid. 

```
ActiveRecord: where(:id => [...])
Mongoid:      where(:id.in => [...])
```

This patch detects Mongoid and adjusts queries accordingly. Tested on Mongoid 4.0.0; should be valid for v3 and v2 as well.

This was broken by #21 (003cdecad55e55e32ed37842947d726b29d29a1d).
