### PR TITLE
Fixes Mongoid Cursor Timeout Issue

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -591,7 +591,7 @@ module AlgoliaSearch
         # don't worry, mongoid has its own underlying cursor/streaming mechanism
         items = []
 
-        per_batch = 100
+        per_batch = 1000
         count = all.count
 
         0.step(count, per_batch) do |offset|

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -590,11 +590,17 @@ module AlgoliaSearch
       else
         # don't worry, mongoid has its own underlying cursor/streaming mechanism
         items = []
-        all.each do |item|
-          items << item
-          if items.length % batch_size == 0
-            yield items
-            items = []
+
+        per_batch = 100
+        count = all.count
+
+        0.step(count, per_batch) do |offset|
+          all.limit(per_batch).skip(offset).each do |item|
+            items << item
+            if items.length % batch_size == 0
+              yield items
+              items = []
+            end
           end
         end
         yield items unless items.empty?


### PR DESCRIPTION
This PR resolves #29 

Mongoid can timeout if it is iterating over a collection for longer than 10 minutes. I have encountered this when performing a Model.reindex! as our primary model pushes a lot of calculated attributes to Algolia. 

The method I've used to get around it is one referenced a few times in: https://github.com/mongoid/mongoid/issues/1334

i.e. manually batching through the collection
