### PR TITLE
Add default index name to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ end
 
 #### Custom index name
 
-You can force the index name using the following option:
+By default, the index name will be the class name, e.g. "Contact". You can customize the index name by using the `index_name` option:
 
 ```ruby
 class Contact < ActiveRecord::Base


### PR DESCRIPTION
I was confused what the index default was until I read the code comments in the **Per-Environment Indexes** section.