### PR TITLE
Added Indexing section to the Quick Start in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,24 @@ class Product < ActiveRecord::Base
 end
 ```
 
+#### Indexing
+
+To index a model, simple call `reindex` on the class:
+
+```ruby
+Product.reindex
+```
+
+To index all of your models, you can do something like this:
+
+```ruby
+Rails.application.eager_load! # Ensure all models are loaded (required in development).
+
+algolia_models = ActiveRecord::Base.descendants.select{ |model| model.respond_to?(:reindex) }
+
+algolia_models.each(&:reindex)
+```
+
 #### Frontend Search (realtime experience)
 
 


### PR DESCRIPTION
An important part to getting things up and running. I had to look elsewhere to find out how to initially index my models.

_There is an outdated Rake task that is suppose to accomplish indexing all your models. If you get that working again, I'd recommend replacing my `descendents` method with calling your Rake task._