### PR TITLE
Fix race condition for without_auto_index

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -773,7 +773,7 @@ module AlgoliaSearch
     end
 
     def algolia_enqueue_remove_from_index!(synchronous)
-      if algoliasearch_options[:enqueue]
+      if algoliasearch_options[:enqueue] && !@algolia_without_auto_index_scope
         algoliasearch_options[:enqueue].call(self, true)
       else
         algolia_remove_from_index!(synchronous)
@@ -781,7 +781,7 @@ module AlgoliaSearch
     end
 
     def algolia_enqueue_index!(synchronous)
-      if algoliasearch_options[:enqueue]
+      if algoliasearch_options[:enqueue] && !@algolia_without_auto_index_scope
         algoliasearch_options[:enqueue].call(self, false)
       else
         algolia_index!(synchronous)


### PR DESCRIPTION
You can disable indexing temporarily using `ClassName.without_auto_index`, but this didn't quite work if you're using a queue due to a race condition. This commit should fix it.

...not sure how to test this though.