### PR TITLE
don't specify synchronous in enqueue methods

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -372,12 +372,12 @@ module AlgoliaSearch
 
             define_method(:after_destroy) do |*args|
               copy_after_destroy.bind(self).call
-              algolia_enqueue_remove_from_index!(algolia_synchronous?)
+              algolia_enqueue_remove_from_index!
               super(*args)
             end
           end
         else
-          after_destroy { |searchable| searchable.algolia_enqueue_remove_from_index!(algolia_synchronous?) } if respond_to?(:after_destroy)
+          after_destroy { |searchable| searchable.algolia_enqueue_remove_from_index! } if respond_to?(:after_destroy)
         end
       end
     end
@@ -772,7 +772,7 @@ module AlgoliaSearch
       self.class.algolia_remove_from_index!(self, synchronous || algolia_synchronous?)
     end
 
-    def algolia_enqueue_remove_from_index!(synchronous)
+    def algolia_enqueue_remove_from_index!(synchronous = false)
       if algoliasearch_options[:enqueue]
         algoliasearch_options[:enqueue].call(self, true)
       else
@@ -780,7 +780,7 @@ module AlgoliaSearch
       end
     end
 
-    def algolia_enqueue_index!(synchronous)
+    def algolia_enqueue_index!(synchronous = false)
       if algoliasearch_options[:enqueue]
         algoliasearch_options[:enqueue].call(self, false)
       else
@@ -814,7 +814,7 @@ module AlgoliaSearch
 
     def algolia_perform_index_tasks
       return if !@algolia_auto_indexing || @algolia_must_reindex == false
-      algolia_enqueue_index!(algolia_synchronous?)
+      algolia_enqueue_index!
       remove_instance_variable(:@algolia_auto_indexing) if instance_variable_defined?(:@algolia_auto_indexing)
       remove_instance_variable(:@algolia_synchronous) if instance_variable_defined?(:@algolia_synchronous)
       remove_instance_variable(:@algolia_must_reindex) if instance_variable_defined?(:@algolia_must_reindex)


### PR DESCRIPTION
Instead of calling `algolia_synchronous?` and passing the result to the
two enqueue methods, we can just set the default to false. This makes
the methods parallel to the non-enqueue versions of these methods, and
they should ultimately behave the same.

There is a nice side-effect to this change, and that is that it makes
the gem more Rails 2 compatible. The one primary reason it isn't
currently is because the `after_destroy` block calls
`algolia_synchronous?` on `self` implicitly. In Rails 2, these blocks
were called with the model _class_ as the context, whereas in Rails 3+
the model _instance_ is.

--

As an aside, I don't know what the thoughts are on rails support, but it looks to me like CI is only set up to run on rails 4. Even if you don't think supporting rails 2 is worthwhile, I think this PR is a decent refactor assuming I haven't glanced over some nuances.