### PR TITLE
disable_tolerance_typo # fix disableTypoToleranceOnAttributes typo

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -62,7 +62,7 @@ module AlgoliaSearch
       :ranking, :customRanking, :queryType, :attributesForFaceting,
       :separatorsToIndex, :optionalWords, :attributeForDistinct,
       :synonyms, :placeholders, :removeWordsIfNoResults, :replaceSynonymsInHighlight,
-      :unretrievableAttributes, :disableTypoToleranceOnAttributes, :altCorrections,
+      :unretrievableAttributes, :disableTypoToleranceOnWords, :disableTypoToleranceOnAttributes, :altCorrections,
       :ignorePlurals, :maxValuesPerFacet, :distinct, :numericAttributesToIndex,
       :allowTyposOnNumericTokens, :allowCompressionOfIntegerArray]
     OPTIONS.each do |k|

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -62,7 +62,7 @@ module AlgoliaSearch
       :ranking, :customRanking, :queryType, :attributesForFaceting,
       :separatorsToIndex, :optionalWords, :attributeForDistinct,
       :synonyms, :placeholders, :removeWordsIfNoResults, :replaceSynonymsInHighlight,
-      :unretrievableAttributes, :disableTypoToleranceOn, :altCorrections,
+      :unretrievableAttributes, :disableTypoToleranceOnAttributes, :altCorrections,
       :ignorePlurals, :maxValuesPerFacet, :distinct, :numericAttributesToIndex,
       :allowTyposOnNumericTokens, :allowCompressionOfIntegerArray]
     OPTIONS.each do |k|


### PR DESCRIPTION
# Why?
Index settings has a typo on the parameter [disableTypoToleranceOnAttributes](https://www.algolia.com/doc/rest-api/search#param-disableTypoToleranceOnAttributes-2)

# What changed?
Renamed parameter from **disableTypoToleranceOn** to **disableTypoToleranceOnAttributes**