### PR TITLE
Whitelist extra options for Algolia API

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -66,7 +66,7 @@ module AlgoliaSearch
       :unretrievableAttributes, :disableTypoToleranceOnWords, :disableTypoToleranceOnAttributes, :altCorrections,
       :ignorePlurals, :maxValuesPerFacet, :distinct, :numericAttributesToIndex, :numericAttributesForFiltering,
       :allowTyposOnNumericTokens, :allowCompressionOfIntegerArray,
-      :advancedSyntax]
+      :advancedSyntax, :disablePrefixOnAttributes, :disableTypoToleranceOnAttributes]
     OPTIONS.each do |k|
       define_method k do |v|
         instance_variable_set("@#{k}", v)


### PR DESCRIPTION
Adds disablePrefixOnAttributes and disableTypoToleranceOnAttributes.

Fixes #193 