### PR TITLE
fix(AlgoliaError): e.status isn't defined, e.code is

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -308,7 +308,7 @@ module AlgoliaSearch
         begin
           @index.get_settings(*args)
         rescue Algolia::AlgoliaError => e
-          return {} if e.status == 404 # not fatal
+          return {} if e.code == 404 # not fatal
           raise e
         end
       end


### PR DESCRIPTION
Not sure why, and if this means we forgot to keep backward comp in `algoliasearch-client-ruby`.