### PR TITLE
Fix algoliasearch:reindex rake task.

### DIFF
--- a/lib/algoliasearch/tasks/algoliasearch.rake
+++ b/lib/algoliasearch/tasks/algoliasearch.rake
@@ -2,7 +2,6 @@ namespace :algoliasearch do
  
   desc "Reindex all models"
   task :reindex => :environment do
-    puts "reindexing all models"
     AlgoliaSearch::Utilities.reindex_all_models
   end
   

--- a/lib/algoliasearch/utilities.rb
+++ b/lib/algoliasearch/utilities.rb
@@ -2,7 +2,9 @@ module AlgoliaSearch
   module Utilities
     class << self
       def get_model_classes
-        AlgoliaSearch.included_in ? AlgoliaSearch.included_in : []
+        Rails.application.eager_load! # Ensure all models are loaded (not necessary in production when cache_classes is true).
+
+        ActiveRecord::Base.descendants.select{ |model| model.respond_to?(:reindex) }
       end
 
       def clear_all_indexes
@@ -12,7 +14,17 @@ module AlgoliaSearch
       end
 
       def reindex_all_models
-        get_model_classes.each do |klass|
+        klasses = get_model_classes
+
+        puts ''
+        puts "Reindexing #{klasses.count} models: #{klasses.to_sentence}."
+        puts ''
+        
+        klasses.each do |klass|
+          say "#{klass}:"
+
+          say "Reindexing #{klass.count} records...", true
+
           klass.reindex
         end
       end


### PR DESCRIPTION
• Updated `AlgoliaSearch::Utilities::get_model_classes` with `respond_to?(:reindex)` checked.
-> Prior to this, it was always return an empty array.

• Update `reindex_all_models` to list models being reindexed and provide console output on the number of records being reindexed.

Here's what the updated output looks like now when you run it: 

![screenshot 2017-03-01 11 07 01](https://cloud.githubusercontent.com/assets/180819/23474000/7cd0908a-fe6f-11e6-9f04-499f7f0494e2.png)

Fixes #37.