### PR TITLE
Make `algolia_without_auto_index_scope` thread safe

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -465,11 +465,11 @@ module AlgoliaSearch
     end
 
     def algolia_without_auto_index_scope=(value)
-      Thread.current["algolia_without_auto_index_scope_for_#{self.name}"] = value
+      Thread.current["algolia_without_auto_index_scope_for_#{self.model_name}"] = value
     end
 
     def algolia_without_auto_index_scope
-      Thread.current["algolia_without_auto_index_scope_for_#{self.name}"]
+      Thread.current["algolia_without_auto_index_scope_for_#{self.model_name}"]
     end
 
     def algolia_reindex!(batch_size = 1000, synchronous = false)


### PR DESCRIPTION
This is a fix for https://github.com/algolia/algoliasearch-rails/issues/234

This makes the `algolia_without_auto_index_scope` thread safe.  Change is to start using `Thread.current` to set and store the scope instead of a class instance variable.  This makes the scope thread safe.