### PR TITLE
Get Settings & Synonyms

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -745,7 +745,7 @@ module AlgoliaSearch
 
       @algolia_indexes[settings] = SafeIndex.new(algolia_index_name(options), algoliasearch_options[:raise_on_failure])
 
-      current_settings = @algolia_indexes[settings].get_settings rescue nil # if the index doesn't exist
+      current_settings = @algolia_indexes[settings].get_settings(getVersion: 1) rescue nil # if the index doesn't exist
 
       index_settings ||= settings.to_settings
       index_settings = options[:primary_settings].to_settings.merge(index_settings) if options[:inherit]


### PR DESCRIPTION
Since we're still using the first version of the synonyms in the Rails
integration, let's force the settings to bet get as v1.