### PR TITLE
Upgrade algoliasearch gem to 1.17.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem 'json', '~> 1.8', '>= 1.8.6'
-gem 'algoliasearch', '~> 1.14.0'
+gem 'algoliasearch', '~> 1.17.0'
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
   gem 'rubysl', '~> 2.0', :platform => :rbx

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.4.0)
-    algoliasearch (1.14.0)
+    algoliasearch (1.17.0)
       httpclient (~> 2.8.3)
       json (>= 1.5.1)
     arel (7.1.4)
@@ -175,7 +175,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-jdbc-adapter
   activerecord-jdbcsqlite3-adapter
-  algoliasearch (~> 1.14.0)
+  algoliasearch (~> 1.17.0)
   jdbc-sqlite3
   json (~> 1.8, >= 1.8.6)
   kaminari
@@ -190,4 +190,4 @@ DEPENDENCIES
   will_paginate (>= 2.3.15)
 
 BUNDLED WITH
-   1.15.3
+   1.16.0

--- a/lib/algoliasearch/version.rb
+++ b/lib/algoliasearch/version.rb
@@ -1,3 +1,3 @@
 module AlgoliaSearch
-  VERSION = '1.20.1'
+  VERSION = '1.20.2'
 end


### PR DESCRIPTION
In order to have access to the new Query Rules endpoints.