### PR TITLE
Do not require rubygems or bundler

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -1,11 +1,3 @@
-begin
-  require "rubygems"
-  require "bundler"
-
-  Bundler.setup :default
-rescue => e
-  puts "AlgoliaSearch: #{e.message}"
-end
 require 'algoliasearch'
 
 require 'algoliasearch/version'


### PR DESCRIPTION
Requiring RubyGems is not necessary since Ruby 1.8, and requiring/initializing Bundler breaks our app startup since Bundler 1.16. 

Here's a stack trace: 
```
ArgumentError:
  Trying to register Bundler::GemfileError for status code 4 but Bundler::GemfileError is already registered
# ./vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `block in require'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `block in require'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `block in require'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/algoliasearch-1.12.7/lib/algoliasearch.rb:8:in `<top (required)>'
# ./vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `block in require'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/algoliasearch-rails-1.19.1/lib/algoliasearch-rails.rb:9:in `<top (required)>'
# ./vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `block in require'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:274:in `require'
# ./config/initializers/algolia.rb:1:in `<top (required)>'
# ./vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `load'
# ./vendor/bundle/ruby/2.3.0/gems/bootsnap-1.1.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `load'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `block in load'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `load'
# ./vendor/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/engine.rb:652:in `block in load_config_initializer'
# ./vendor/bundle/ruby/2.3.0/gems/activesupport-4.2.10/lib/active_support/notifications.rb:166:in `instrument'
# ./vendor/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/engine.rb:651:in `load_config_initializer'
# ./vendor/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/engine.rb:616:in `block (2 levels) in <class:Engine>'
# ./vendor/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/engine.rb:615:in `each'
# ./vendor/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/engine.rb:615:in `block in <class:Engine>'
# ./vendor/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/initializable.rb:30:in `instance_exec'
# ./vendor/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/initializable.rb:30:in `run'
# ./vendor/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/initializable.rb:55:in `block in run_initializers'
# ./vendor/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/initializable.rb:44:in `each'
# ./vendor/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/initializable.rb:44:in `tsort_each_child'
# ./vendor/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/initializable.rb:54:in `run_initializers'
# ./vendor/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/application.rb:352:in `initialize!'
# ./vendor/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/railtie.rb:194:in `public_send'
# ./vendor/bundle/ruby/2.3.0/gems/railties-4.2.10/lib/rails/railtie.rb:194:in `method_missing'
# ./config/environment.rb:5:in `<top (required)>'
# ./spec/spec_helper.rb:8:in `require'
``` 

Things work without the deleted require statements. 