### PR TITLE
Use Algolia Key Dealer to allow contributors outside of Algolia to run Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,3 @@ before_install:
 install: rm -f Gemfile.lock && bundle install
 cache: bundler
 script: eval $(./algolia-keys export) && bundle exec rake
-env:
-  global:
-  - secure: "o/Hi/6KnBugN5P/cpVtpwyKrK5fVzAc0efw+qZ9ZqwqZN0GmipZrHmRNuLVUxVf+CIcqfLpIT0U172XGOZ5zJ1gs3qZZrDsJ1ptXnPyvvCrw+VX5yGhMh67JnlO0WLWvci0WdltJTmrhCoLSSw39nCPswC7I6/hai4KyiOXoMk4="
-  - secure: "Jv9jOYRwJq5i17Int/p75330yxCJXKLYlstHuBjwkKa6anJHFSXQaAxWj8sZHCY4IAVDsBfdi0j6S3dtVu2LaVLA3hfPp36YRVolSZu9zLbGqyPKBWM7E3i7GkS3Jub0nMV3Yo3cMeiFzQ4BmpSQOYo0biCkL8bh4/5NRZ7Q6VI="

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,12 @@ matrix:
   allow_failures:
   - rvm: rbx-2
 before_install:
+  - wget http://api-key-dealer.herokuapp.com/clients/algolia-keys && chmod +x algolia-keys
   - gem install bundler
   - bundle --version
 install: rm -f Gemfile.lock && bundle install
 cache: bundler
+script: eval $(./algolia-keys export) && bundle exec rake
 env:
   global:
   - secure: "o/Hi/6KnBugN5P/cpVtpwyKrK5fVzAc0efw+qZ9ZqwqZN0GmipZrHmRNuLVUxVf+CIcqfLpIT0U172XGOZ5zJ1gs3qZZrDsJ1ptXnPyvvCrw+VX5yGhMh67JnlO0WLWvci0WdltJTmrhCoLSSw39nCPswC7I6/hai4KyiOXoMk4="

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,5 +32,5 @@ end
 def safe_index_name(name)
   return name if ENV['TRAVIS'].to_s != "true"
   id = ENV['TRAVIS_JOB_NUMBER'].split('.').last
-  "#{name}_travis-#{id}"
+  "TRAVIS_RAILS_#{name}_#{id}"
 end


### PR DESCRIPTION
Testing Key Dealer project. This should allow public PRs to run specs with a custom key valid only for this PR.

cc @julienbourdeau 