### PR TITLE
fix(sequel): correctly call after_commit for Sequel 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,9 @@ matrix:
   - rvm: 2.4.1
     env: RAILS_VERSION=4.2
   - rvm: 2.4.1
-    env: RAILS_VERSION=5.1
+    env: RAILS_VERSION=5.1 SEQUEL_VERSION=4.0
+  - rvm: 2.4.1
+    env: RAILS_VERSION=5.1 SEQUEL_VERSION=5.0
   # - rvm: jruby-9.1.2.0
   #   env: RAILS_VERSION=3.2.0
   # - rvm: jruby-9.1.2.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,6 @@ before_install:
   - wget http://api-key-dealer.herokuapp.com/clients/algolia-keys && chmod +x algolia-keys
   - gem install bundler
   - bundle --version
-install: rm -f Gemfile.lock && bundle install
+install: rm -f Gemfile.lock && bundle install --without development
 cache: bundler
 script: eval $(./algolia-keys export) && bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,9 @@ group :test do
   gem 'activerecord-jdbc-adapter', :platform => :jruby
   gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby
   gem 'redgreen'
-  gem 'sequel', '< 5.0'
+
+  sequel_version = ENV['SEQUEL_VERSION'] ? "~> #{ENV['SEQUEL_VERSION']}" : '>= 4.0'
+  gem 'sequel', sequel_version
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
     rspec-expectations (2.99.2)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.99.4)
-    sequel (4.44.0)
+    sequel (4.49.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -175,7 +175,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord-jdbc-adapter
   activerecord-jdbcsqlite3-adapter
-  algoliasearch (~> 1.17.0)
+  algoliasearch (>= 1.17.0, < 2.0.0)
   jdbc-sqlite3
   json (~> 1.8, >= 1.8.6)
   kaminari

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -402,7 +402,6 @@ module AlgoliaSearch
           class_eval do
             copy_after_validation = instance_method(:after_validation)
             copy_before_save = instance_method(:before_save)
-            copy_after_commit = instance_method(:after_commit)
 
             define_method(:after_validation) do |*args|
               super(*args)
@@ -416,10 +415,23 @@ module AlgoliaSearch
               super(*args)
             end
 
-            define_method(:after_commit) do |*args|
-              super(*args)
-              copy_after_commit.bind(self).call
-              algolia_perform_index_tasks
+            sequel_version = Gem::Version.new(Sequel.version)
+            if sequel_version >= Gem::Version.new('4.0.0') && sequel_version < Gem::Version.new('5.0.0')
+              copy_after_commit = instance_method(:after_commit)
+              define_method(:after_commit) do |*args|
+                super(*args)
+                copy_after_commit.bind(self).call
+                algolia_perform_index_tasks
+              end
+            else
+              copy_after_save = instance_method(:after_save)
+              define_method(:after_save) do |*args|
+                super(*args)
+                copy_after_save.bind(self).call
+                self.db.after_commit do
+                  algolia_perform_index_tasks
+                end
+              end
             end
           end
         else

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -275,7 +275,7 @@ class City < ActiveRecord::Base
   end
 end
 
-class SequelBook < Sequel::Model
+class SequelBook < Sequel::Model(SEQUEL_DB)
   plugin :active_model
 
   include AlgoliaSearch
@@ -304,7 +304,6 @@ class SequelBook < Sequel::Model
     released && !premium
   end
 end
-SequelBook.db = SEQUEL_DB
 
 describe 'SequelBook' do
   before(:all) do


### PR DESCRIPTION
Try to apply the patch offered by the Changelog linked by
@redox in #264.
I believe this way is the proper way of finally solving the issue

I've added an entry to the travis build matrix to test with:
- Rails 5 with Sequel 4
- Rails 5 with Sequel 5

Closes #264
Closes #270
Reverts #287