### PR TITLE
Disable query cache while reindexing

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -903,7 +903,9 @@ module AlgoliaSearch
 
     def algolia_find_in_batches(batch_size, &block)
       if (defined?(::ActiveRecord) && ancestors.include?(::ActiveRecord::Base)) || respond_to?(:find_in_batches)
-        find_in_batches(:batch_size => batch_size, &block)
+        ActiveRecord::Base.uncached do
+          find_in_batches(:batch_size => batch_size, &block)
+        end
       elsif defined?(::Sequel) && self < Sequel::Model
         dataset.extension(:pagination).each_page(batch_size, &block)
       else


### PR DESCRIPTION
`algoliasearch-rails` has a memory leak when reindexing in Rails while using ActiveRecord. The culprit is the `algolia_find_in_batches` method, which calls ActiveRecord's `find_in_batches` method. This method keeps adding to the query cache, which for large record sets will eventually cause memory to run out.

My PR simply disables the query cache when running `find_in_batches`, effectively disabling the query cache during reindexing and thus fixing the memory leak.