### PR TITLE
Disable settings change checks and introduce set_all_settings command

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -782,7 +782,9 @@ module AlgoliaSearch
       index_settings ||= settings.to_settings
       index_settings = options[:primary_settings].to_settings.merge(index_settings) if options[:inherit]
 
-      if !algolia_indexing_disabled?(options) && algoliasearch_settings_changed?(current_settings, index_settings)
+      options[:check_settings] = true if options[:check_settings].nil?
+
+      if !algolia_indexing_disabled?(options) && options[:check_settings] && algoliasearch_settings_changed?(current_settings, index_settings)
         used_slaves = !current_settings.nil? && !current_settings['slaves'].nil?
         replicas = index_settings.delete(:replicas) ||
                    index_settings.delete('replicas') ||

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -576,6 +576,12 @@ module AlgoliaSearch
       nil
     end
 
+    def algolia_set_settings(synchronous = false)
+      index = SafeIndex.new(algolia_index_name, true)
+      task = index.set_settings(algoliasearch_settings.to_settings)
+      index.wait_task(task["taskID"]) if synchronous
+    end
+
     def algolia_index_objects(objects, synchronous = false)
       algolia_configurations.each do |options, settings|
         next if algolia_indexing_disabled?(options)

--- a/lib/algoliasearch/tasks/algoliasearch.rake
+++ b/lib/algoliasearch/tasks/algoliasearch.rake
@@ -1,8 +1,13 @@
 namespace :algoliasearch do
- 
+
   desc "Reindex all models"
   task :reindex => :environment do
     AlgoliaSearch::Utilities.reindex_all_models
+  end
+
+  desc "Set settings to all indexes"
+  task :set_settings => :environment do
+    AlgoliaSearch::Utilities.set_settings_all_models
   end
   
   desc "Clear all indexes"

--- a/lib/algoliasearch/tasks/algoliasearch.rake
+++ b/lib/algoliasearch/tasks/algoliasearch.rake
@@ -6,7 +6,7 @@ namespace :algoliasearch do
   end
 
   desc "Set settings to all indexes"
-  task :set_settings => :environment do
+  task :set_all_settings => :environment do
     AlgoliaSearch::Utilities.set_settings_all_models
   end
   

--- a/lib/algoliasearch/utilities.rb
+++ b/lib/algoliasearch/utilities.rb
@@ -25,6 +25,19 @@ module AlgoliaSearch
           klass.algolia_reindex
         end
       end
+
+      def set_settings_all_models
+        klasses = get_model_classes
+
+        puts ''
+        puts "Pushing settings for #{klasses.count} models: #{klasses.to_sentence}."
+        puts ''
+
+        klasses.each do |klass|
+          puts "Pushing #{klass} settings..."
+          klass.algolia_set_settings
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
The Rails integration will compare your local settings and the index settings in Algolia when using an index. It can leads to a lot of getSettings calls so I introduce a new `check_settings` option that can disable this behavior if set to false.

Example

```ruby
class Musician < ActiveRecord::Base
  include AlgoliaSearch

  algoliasearch per_environment: true, check_settings: false do
    searchableAttributes ['name', 'band']
  end
end
```

### Push settings to all indices

If you use this feature, you will need to push settings manually when you modify them in your model configuration. This PR also add a new `rake algoliasearch:set_all_settings` command to push settings for all models.
It inherit settings from primary indices and set settings to replicas and additional indices.