### PR TITLE
Add decompoundedAttributes to OPTIONS

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -60,7 +60,7 @@ module AlgoliaSearch
       :ignorePlurals, :maxValuesPerFacet, :distinct, :numericAttributesToIndex, :numericAttributesForFiltering,
       :allowTyposOnNumericTokens, :allowCompressionOfIntegerArray,
       :advancedSyntax, :disablePrefixOnAttributes,
-      :paginationLimitedTo]
+      :paginationLimitedTo, :decompoundedAttributes]
     OPTIONS.each do |k|
       define_method k do |v|
         instance_variable_set("@#{k}", v)


### PR DESCRIPTION
It seems that `decomputedAttributes` (https://www.algolia.com/doc/api-reference/api-parameters/decompoundedAttributes/) are missing from `OPTIONS`

solve: https://github.com/algolia/algoliasearch-rails/issues/310