### PR TITLE
Fix Travis index names

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,6 @@ end
 # avoid concurrent access to the same index
 def safe_index_name(name)
   return name if ENV['TRAVIS'].to_s != "true"
-  id = ENV['TRAVIS_JOB_NUMBER'].split('.').last
+  id = ENV['TRAVIS_JOB_NUMBER']
   "TRAVIS_RAILS_#{name}_#{id}"
 end


### PR DESCRIPTION
When a job number is 92.4, we only used the last part (4 in this
example). but if the build job 93 starts at the same time, there
will be a 93.4 job conflicting with 92.4.