### PR TITLE
Don't use deprecated attribute_changed?

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -715,14 +715,14 @@ module AlgoliaSearch
         next if options[:slave] || options[:replica]
         return true if algolia_object_id_changed?(object, options)
         settings.get_attribute_names(object).each do |k|
-          changed_method = "#{k}_changed?"
+          changed_method = attribute_changed_method(k)
           return true if !object.respond_to?(changed_method) || object.send(changed_method)
         end
         [options[:if], options[:unless]].each do |condition|
           case condition
           when nil
           when String, Symbol
-            changed_method = "#{condition}_changed?"
+            changed_method = attribute_changed_method(condition)
             return true if !object.respond_to?(changed_method) || object.send(changed_method)
           else
             # if the :if, :unless condition is a anything else,
@@ -797,7 +797,7 @@ module AlgoliaSearch
     end
 
     def algolia_object_id_changed?(o, options = nil)
-      m = "#{algolia_object_id_method(options)}_changed?"
+      m = attribute_changed_method(algolia_object_id_method(options))
       o.respond_to?(m) ? o.send(m) : false
     end
 
@@ -889,6 +889,15 @@ module AlgoliaSearch
           end
         end
         yield items unless items.empty?
+      end
+    end
+
+    def attribute_changed_method attr
+      if ActiveRecord::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 1 ||
+          ActiveRecord::Version::MAJOR > 5
+        "will_save_change_to_#{attr}?"
+      else
+        "#{attr}_changed?"
       end
     end
   end

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -892,9 +892,8 @@ module AlgoliaSearch
       end
     end
 
-    def attribute_changed_method attr
-      if ActiveRecord::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 1 ||
-          ActiveRecord::Version::MAJOR > 5
+    def attribute_changed_method(attr)
+      if ActiveRecord::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 1
         "will_save_change_to_#{attr}?"
       else
         "#{attr}_changed?"

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -893,8 +893,8 @@ module AlgoliaSearch
     end
 
     def attribute_changed_method(attr)
-      if ActiveRecord::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 1
-        || ActiveRecord::VERSION::MAJOR > 5
+      if ActiveRecord::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 1 ||
+          ActiveRecord::VERSION::MAJOR > 5
         "will_save_change_to_#{attr}?"
       else
         "#{attr}_changed?"

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -894,6 +894,7 @@ module AlgoliaSearch
 
     def attribute_changed_method(attr)
       if ActiveRecord::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 1
+        || ActiveRecord::VERSION::MAJOR > 5
         "will_save_change_to_#{attr}?"
       else
         "#{attr}_changed?"


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no 
| BC breaks?        | no     
| Related Issue     | Fix #263
| Need Doc update   | no

## Describe your change

This is the same code as PR https://github.com/algolia/algoliasearch-rails/pull/263 (which has been stale for more than a year), but fixed with all tests hopefully passing.

## What problem is this fixing?

PR https://github.com/algolia/algoliasearch-rails/pull/263 used `ActiveRecord::Version` which doesn't exist: only `ActiveRecord::VERSION` exists. My PR fixes that.

The end goal of both this PR and the original PR is to use non-deprecated fields.