### PR TITLE
Add safe index name prefix and after suite index deletion

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,7 +45,7 @@ end
 
 # get a list of safe indexes in local or CI
 def safe_index_list
-  Algolia.client.list_indexes()['items']
-    .select { |index| index["name"].include?(SAFE_INDEX_PREFIX) }
-    .sort_by { |index| index["primary"] || "" }
+  list = Algolia.client.list_indexes()['items']
+  list = list.select { |index| index["name"].include?(SAFE_INDEX_PREFIX) }
+  list.sort_by { |index| index["primary"] || "" }
 end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #323 
| Need Doc update   | no

## Describe your change

The change is a method to delete indexes after the test suite runs & to make `index_names` truely unique to prevent concurreny issues.

1. Add secure random for true unique index names.
1. Add a rails specific prefix for easy identification.
1. Filter created indexes by secure random for deleting.
1. Sort indices so we don't attempt to delete a replica or slave before its primary.

The below example show the safe execution does not delete the `DoNotDelete` index.

#### During Testing
![while_suite_ran](https://user-images.githubusercontent.com/30017294/49573183-4cb03780-f935-11e8-9276-6bf6fbb68917.png)


#### After Testing
![after_suite_ran](https://user-images.githubusercontent.com/30017294/49573173-4621c000-f935-11e8-9d3a-a83093548d64.png)


## What problem is this fixing?

spec/integration_spec.rb:962 expects a replica to contain `nil` in `attributesToIndex`
spec/integration_spec.rb:974 adds `second_value` to `attributesToIndex`

This passes on the first run of the suite. On the next run the expectation of `nil` does not equal `second_value` so the test suite fails.