### PR TITLE
Add support for all recent settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
 matrix:
   include:
   - rvm: 1.8.7
-    env: RAILS_VERSION=3.2.0
+    env: RAILS_VERSION=3.2.0 SEQUEL_VERSION=4.0
   - rvm: 1.9.3
     env: RAILS_VERSION=3.2.0
   - rvm: 1.9.3

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :test do
   elsif defined?(RUBY_VERSION) && RUBY_VERSION == "1.9.3"
     gem 'rack', '< 2'
     gem 'nokogiri', '< 1.7.0'
+    gem 'rack-cache', '<= 1.7.1'
     if Gem::Version.new(ENV['RAILS_VERSION'] || '3.2.0') >= Gem::Version.new('4.0')
       gem 'mime-types', '~> 2.6'
     else

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -47,21 +47,43 @@ module AlgoliaSearch
   end
 
   class IndexSettings
+    DEFAULT_BATCH_SIZE = 1000
 
     # AlgoliaSearch settings
-    DEFAULT_BATCH_SIZE = 1000
-    OPTIONS = [:minWordSizefor1Typo, :minWordSizefor2Typos, :typoTolerance,
-      :hitsPerPage, :attributesToRetrieve,
-      :attributesToHighlight, :attributesToSnippet, :attributesToIndex, :searchableAttributes,
-      :highlightPreTag, :highlightPostTag,
-      :ranking, :customRanking, :queryType, :attributesForFaceting,
-      :separatorsToIndex, :optionalWords, :attributeForDistinct,
-      :synonyms, :placeholders, :removeWordsIfNoResults, :replaceSynonymsInHighlight,
-      :unretrievableAttributes, :disableTypoToleranceOnWords, :disableTypoToleranceOnAttributes, :altCorrections,
-      :ignorePlurals, :maxValuesPerFacet, :distinct, :numericAttributesToIndex, :numericAttributesForFiltering,
-      :allowTyposOnNumericTokens, :allowCompressionOfIntegerArray,
-      :advancedSyntax, :disablePrefixOnAttributes,
-      :paginationLimitedTo]
+    OPTIONS = [
+      # Attributes
+      :searchableAttributes, :attributesForFaceting, :unretrievableAttributes, :attributesToRetrieve,
+      :attributesToIndex, #Legacy name of searchableAttributes
+      # Ranking
+      :ranking, :customRanking, # Replicas are handled via `add_replica`
+      # Faceting
+      :maxValuesPerFacet, :sortFacetValuesBy,
+      # Highlighting / Snippeting
+      :attributesToHighlight, :attributesToSnippet, :highlightPreTag, :highlightPostTag,
+      :snippetEllipsisText, :restrictHighlightAndSnippetArrays,
+      # Pagination
+      :hitsPerPage, :paginationLimitedTo,
+      # Typo
+      :minWordSizefor1Typo, :minWordSizefor2Typos, :typoTolerance, :allowTyposOnNumericTokens,
+      :disableTypoToleranceOnAttributes, :disableTypoToleranceOnWords, :separatorsToIndex,
+      # Language
+      :ignorePlurals, :removeStopWords, :camelCaseAttributes, :decompoundedAttributes,
+      :keepDiacriticsOnCharacters, :queryLanguages,
+      # Query Rules
+      :enableRules,
+      # Query Strategy
+      :queryType, :removeWordsIfNoResults, :advancedSyntax, :optionalWords,
+      :disablePrefixOnAttributes, :disableExactOnAttributes, :exactOnSingleWordQuery, :alternativesAsExact,
+      # Performance
+      :numericAttributesForFiltering, :allowCompressionOfIntegerArray,
+      :numericAttributesToIndex, # Legacy name of numericAttributesForFiltering
+      # Advanced
+      :attributeForDistinct, :distinct, :replaceSynonymsInHighlight, :minProximity, :responseFields,
+      :maxFacetHits,
+
+      # Rails-specific
+      :synonyms, :placeholders, :altCorrections,
+    ]
     OPTIONS.each do |k|
       define_method k do |v|
         instance_variable_set("@#{k}", v)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

```ruby
  algoliasearch per_environment: true do
    searchableAttributes ['name', 'unordered(email)', 'company']
    attributesForFaceting ['company']
    keepDiacriticsOnCharacters "char"
  end
```

In order to manage your settings as show before, all settings must be declared by the extension. I have updated the list and reorganize it according to the [documentation](https://www.algolia.com/doc/api-reference/api-parameters/query/), hoping this would make it easier to update
