### PR TITLE
Ensure ActiveRecord is loaded (fix #328)

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -893,8 +893,8 @@ module AlgoliaSearch
     end
 
     def attribute_changed_method(attr)
-      if ActiveRecord::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 1 ||
-          ActiveRecord::VERSION::MAJOR > 5
+      if defined?(::ActiveRecord) && ActiveRecord::VERSION::MAJOR >= 5 && ActiveRecord::VERSION::MINOR >= 1 ||
+          (defined?(::ActiveRecord) && ActiveRecord::VERSION::MAJOR > 5)
         "will_save_change_to_#{attr}?"
       else
         "#{attr}_changed?"


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #328 


## Describe your change

If ActiveRecord is not loaded, the change introduced in #325 would break. This fix makes sure ActiveRecord is loaded before accessing its contants.
