### PR TITLE
Fix 404 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You might be interested in the sample Ruby on Rails application providing a `aut
 
 ## API Documentation
 
-You can find the full reference on [Algolia's website](https://www.algolia.com/doc/api-client/rails/).
+You can find the full reference on [Algolia's website](https://www.algolia.com/doc/framework-integration/rails/setup/).
 
 
 


### PR DESCRIPTION
Current reference URL leads to 404. I've replaced it with where I think it should point, but you may have to double check that. I understand README is auto-generated, but thought it would be easier to show than just tell.