### PR TITLE
Introduce :inherit_attributes and :inherit_settings options to reduce code duplication

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem 'json', '~> 1.8', '>= 1.8.6'
-gem 'algoliasearch', '>= 1.23.0', '< 2.0.0'
+gem 'algoliasearch', '>= 1.26.0', '< 2.0.0'
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
   gem 'rubysl', '~> 2.0', :platform => :rbx

--- a/algoliasearch-rails.gemspec
+++ b/algoliasearch-rails.gemspec
@@ -87,11 +87,11 @@ Gem::Specification.new do |s|
       s.add_development_dependency "rdoc"
     else
       s.add_dependency(%q<json>, [">= 1.5.1"])
-      s.add_dependency(%q<algoliasearch>, [">= 1.17.0", "< 2.0.0"])
+      s.add_dependency(%q<algoliasearch>, [">= 1.26.0", "< 2.0.0"])
     end
   else
     s.add_dependency(%q<json>, [">= 1.5.1"])
-    s.add_dependency(%q<algoliasearch>, [">= 1.17.0", "< 2.0.0"])
+    s.add_dependency(%q<algoliasearch>, [">= 1.26.0", "< 2.0.0"])
   end
 end
 

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -272,19 +272,22 @@ module AlgoliaSearch
       @additional_indexes ||= {}
       raise MixedSlavesAndReplicas.new('Cannot mix slaves and replicas in the same configuration (add_slave is deprecated)') if (options[:slave] && @additional_indexes.any? { |opts, _| opts[:replica] }) || (options[:replica] && @additional_indexes.any? { |opts, _| opts[:slave] })
       options[:index_name] = index_name
+
+      options.merge!({ :primary_settings => self }) if options[:inherit]
+
       @additional_indexes[options] = IndexSettings.new(options, Proc.new)
     end
 
     def add_replica(index_name, options = {}, &block)
       raise ArgumentError.new('Cannot specify additional replicas on a replica index') if @options[:slave] || @options[:replica]
       raise ArgumentError.new('No block given') if !block_given?
-      add_index(index_name, options.merge({ :replica => true, :primary_settings => self }), &block)
+      add_index(index_name, options.merge({ :replica => true }), &block)
     end
 
     def add_slave(index_name, options = {}, &block)
       raise ArgumentError.new('Cannot specify additional slaves on a slave index') if @options[:slave] || @options[:replica]
       raise ArgumentError.new('No block given') if !block_given?
-      add_index(index_name, options.merge({ :slave => true, :primary_settings => self }), &block)
+      add_index(index_name, options.merge({ :slave => true }), &block)
     end
 
     def additional_indexes

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -558,18 +558,15 @@ module AlgoliaSearch
         master_settings.delete 'replicas'
 
         # init temporary index
-        index_name = algolia_index_name(options)
-        tmp_options = options.merge({ :index_name => "#{index_name}.tmp" })
-        tmp_options.delete(:per_environment) # already included in the temporary index_name
-        tmp_settings = settings.dup
-        tmp_index = algolia_ensure_init(tmp_options, tmp_settings, master_settings)
+        ::Algolia::copy_index!(index_name, "#{index_name}.tmp", %w(settings synonyms rules))
+        tmp_index = SafeIndex.new("#{index_name}.tmp", !!options[:raise_on_failure])
 
         algolia_find_in_batches(batch_size) do |group|
-          if algolia_conditional_index?(tmp_options)
+          if algolia_conditional_index?(options)
             # select only indexable objects
-            group = group.select { |o| algolia_indexable?(o, tmp_options) }
+            group = group.select { |o| algolia_indexable?(o, options) }
           end
-          objects = group.map { |o| tmp_settings.get_attributes(o).merge 'objectID' => algolia_object_id_of(o, tmp_options) }
+          objects = group.map { |o| settings.get_attributes(o).merge 'objectID' => algolia_object_id_of(o, options) }
           tmp_index.save_objects(objects)
         end
 

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -563,7 +563,7 @@ module AlgoliaSearch
       nil
     end
 
-    # reindex whole database using a extra temporary index + move operation
+    # reindex whole database using a temporary index + move operation
     def algolia_reindex(batch_size = AlgoliaSearch::IndexSettings::DEFAULT_BATCH_SIZE, synchronous = false)
       return if algolia_without_auto_index_scope
 
@@ -617,7 +617,7 @@ module AlgoliaSearch
 
     def algolia_set_settings(synchronous = false)
       algolia_configurations.each do |options, settings|
-        if options[:primary_settings] && options[:inherit]
+        if options[:primary_settings] && (options[:inherit] || options[:inherit_settings])
           primary = options[:primary_settings].to_settings
           primary.delete :slaves
           primary.delete 'slaves'

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -591,8 +591,7 @@ module AlgoliaSearch
           next
         end
 
-        # options[:index_name] for add_index, index_name for main index
-        src_index_name = options[:index_name] || index_name
+        src_index_name = algolia_index_name(options)
 
         # init temporary index
         ::Algolia::copy_index!(src_index_name, "#{src_index_name}.tmp", %w(settings synonyms rules))


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | yes


## Describe your change

`add_replica` let you inherit index settings from the primary index. This PR add this feature to `add_index`as well.

Partially fixes #296. It only inherit settings, I have to also inherit attributes (and additional attributes) which I think is doable. It wasn't required for `add_replica`since a replica has the same content as a primary index by design.

Note that the parent index is called "primary" even for add_index, which can be misleading since it's not a primary/replica relationship. I'd rather keep this name since it seems some users are already passing the `:primary_index => self` option explicitely (see #296).

### TODO:

- [x] Inherit settings for `add_index`
- [x] Inherit settings for `add_replica`
- [x] Inherit serialization logic (attributes) for `add_index`
    - [x] Including Additional attributes (tags and geoloc)
- [ ] Ensure these changes are 100% backward compatible
- [x] Set settings for replicas of additional index - Fix #186
- [x] Additonal index don't inherit replicas


## 📝 To document

- [ ] 🆕 `Model.reindex` will set_settings on all indices of the model (incl replicas).
- [ ] New Inherit capabilities (of course)
