### PR TITLE
Update total_hits assignment for pagination to passthrough nbHits directly

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -698,8 +698,7 @@ module AlgoliaSearch
         end
       end.compact
       # Algolia has a default limit of 1000 retrievable hits
-      total_hits = json['nbHits'].to_i < json['nbPages'].to_i * json['hitsPerPage'].to_i ?
-        json['nbHits'].to_i: json['nbPages'].to_i * json['hitsPerPage'].to_i
+      total_hits = json['nbHits'].to_i
       res = AlgoliaSearch::Pagination.create(results, total_hits, algoliasearch_options.merge({ :page => json['page'].to_i + 1, :per_page => json['hitsPerPage'] }))
       res.extend(AdditionalMethods)
       res.send(:algolia_init_raw_answer, json)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    
| BC breaks?        | no     
| Related Issue     | 
| Need Doc update   | no


## Describe your change

This change simplifies the assignment of `total_hits` within the `algolia_search` method. Instead of calculating `total_hits` from a confusing (perhaps unnecessary?) conditional it will now simply pass through the value from the Algolia API, which we should trust as being correct.

## What problem is this fixing?

I was wondering why the pagination strategy in this gem is more complicated than it needs to be. To help explain my curiosity, here is a scenario:

I have an index with more than 50k records. When you perform an empty search (no query or filters) on Algolia (or direct via the API) the response payload includes `nbHits` which _feels_ accurate to the number of records in the index:

![screenshot](https://cl.ly/fa1e3586d583/Screen%20Shot%202019-02-15%20at%201.19.52%20PM.png)

Using this gem to perform the exact same query and simply piping the Kaminari paginator to output the response payload includes `total_count` which is crazy lower than the expected number of records:

![screenshot](https://cl.ly/c9d416d09472/Screen%20Shot%202019-02-15%20at%201.19.11%20PM.png)

At first, I thought something was suspect with the Kaminari adapter. As I looked deeper into this gem I find this snippet of code that looks to be very likely the culprit:

https://github.com/algolia/algoliasearch-rails/blob/e22691ad6ea5428e33b04ab403db080a6b443df6/lib/algoliasearch-rails.rb#L700-L703

Specifically we see this comment:

```ruby
# Algolia has a default limit of 1000 retrievable hits
```

Ok? What does that have to do with `total_count`? Then the next two lines include some condition that appears to do some comparison to determine if the `nbHits` is less than the product of `nbPages` times `hitsPerPage`? Why is this logic here? You can see from the "direct Algolia API" screenshot above, my page will always hit the `else` condition of that logic because 52233 > (100 * 10).

Unless I am missing something (which I've been known to do) it seems to me that this should be a straightforward assignment of:

```ruby
total_hits = json['nbHits'].to_i 
```

If I am wrong, will someone please explain the use case, or justification, for the current logic?

Also, I am guessing this was never caught by the automated test suite because the ActiveRecord models used in the tests appear to only exercise a relatively small amount of data.