### PR TITLE
Fix _changed? BC break and introduce algolia_dirty? method

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -938,8 +938,7 @@ module AlgoliaSearch
         # If it's automatic we check ActiveRecord version to see if this method is deprecated
         # and try to call +will_save_change_to_#{attr_name}?+ instead.
         # See: https://github.com/algolia/algoliasearch-rails/pull/338
-        rails_magic_def = object.method(method_name).source_location[0].end_with?("active_model/attribute_methods.rb")
-        unless rails_magic_def && automatic_changed_method_deprecated?
+        unless automatic_changed_method?(object, method_name) && automatic_changed_method_deprecated?
           return object.send(method_name)
         end
       end
@@ -950,6 +949,16 @@ module AlgoliaSearch
 
       # Nil means we don't know if the attribute has changed
       nil
+    end
+
+    def automatic_changed_method?(object, method_name)
+      raise ArgumentError.new("Method #{method_name} doesn't exist on #{object.class.name}") unless object.respond_to?(method_name)
+      if defined?(:RUBY_VERSION) && RUBY_VERSION.to_f < 1.9
+        file = object.method(method_name).__file__
+      else
+        file = object.method(method_name).source_location[0]
+      end
+      file.end_with?("active_model/attribute_methods.rb")
     end
 
     def automatic_changed_method_deprecated?

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -739,6 +739,9 @@ module AlgoliaSearch
     end
 
     def algolia_must_reindex?(object)
+      # use +algolia_dirty?+ method if implemented
+      return object.send(:algolia_dirty?) if (object.respond_to?(:algolia_dirty?))
+      # Loop over each index to see if a attribute used in records has changed
       algolia_configurations.each do |options, settings|
         next if options[:slave] || options[:replica]
         return true if algolia_object_id_changed?(object, options)
@@ -759,6 +762,7 @@ module AlgoliaSearch
           end
         end
       end
+      # By default, we don't reindex
       return false
     end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -167,6 +167,10 @@ class Color < ActiveRecord::Base
 
     # we're using all attributes of the Color class + the _tag "extra" attribute
   end
+
+  def hex_changed?
+    false
+  end
 end
 
 class DisabledBoolean < ActiveRecord::Base
@@ -542,14 +546,18 @@ describe 'Change detection' do
     color.save
     Color.algolia_must_reindex?(color).should == false
 
+    color.hex = 123456
+    Color.algolia_must_reindex?(color).should == false
+
     color.not_indexed = "strstr"
     Color.algolia_must_reindex?(color).should == false
     color.name = "red"
     Color.algolia_must_reindex?(color).should == true
+
+    color.delete
   end
 
 end
-
 
 describe 'Namespaced::Model' do
   it "should have an index name without :: hierarchy" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -594,7 +594,7 @@ describe 'Change detection' do
     Ebook.algolia_must_reindex?(ebook).should == false
   end
 
-  it "should know if the _changed? method is user-defined" do
+  it "should know if the _changed? method is user-defined", :skip => Object.const_defined?(:RUBY_VERSION) && RUBY_VERSION.to_f < 1.9 do
     color = Color.new :name => "dark-blue", :short_name => "blue"
 
     expect { Color.send(:automatic_changed_method?, color, :something_that_doesnt_exist) }.to raise_error(ArgumentError)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -155,6 +155,7 @@ end
 
 class Color < ActiveRecord::Base
   include AlgoliaSearch
+  attr_accessor :not_indexed
 
   algoliasearch :synchronous => true, :index_name => safe_index_name("Color"), :per_environment => true do
     attributesToIndex [:name]
@@ -531,6 +532,24 @@ describe 'Settings' do
   end
 
 end
+
+describe 'Change detection' do
+
+  it "should detect settings changes" do
+    color = Color.new name: "dark-blue", short_name: "blue"
+
+    Color.algolia_must_reindex?(color).should == true
+    color.save
+    Color.algolia_must_reindex?(color).should == false
+
+    color.not_indexed = "strstr"
+    Color.algolia_must_reindex?(color).should == false
+    color.name = "red"
+    Color.algolia_must_reindex?(color).should == true
+  end
+
+end
+
 
 describe 'Namespaced::Model' do
   it "should have an index name without :: hierarchy" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -177,6 +177,10 @@ class Color < ActiveRecord::Base
   def hex_changed?
     false
   end
+
+  def will_save_change_to_short_name?
+    false
+  end
 end
 
 class DisabledBoolean < ActiveRecord::Base
@@ -588,6 +592,23 @@ describe 'Change detection' do
     Ebook.algolia_must_reindex?(ebook).should == true
     ebook.published_at = 12
     Ebook.algolia_must_reindex?(ebook).should == false
+  end
+
+  it "should know if the _changed? method is user-defined" do
+    color = Color.new :name => "dark-blue", :short_name => "blue"
+
+    expect { Color.send(:automatic_changed_method?, color, :something_that_doesnt_exist) }.to raise_error(ArgumentError)
+
+    Color.send(:automatic_changed_method?, color, :name_changed?).should == true
+    Color.send(:automatic_changed_method?, color, :hex_changed?).should == false
+
+    Color.send(:automatic_changed_method?, color, :will_save_change_to_short_name?).should == false
+
+    if Color.send(:automatic_changed_method_deprecated?)
+      Color.send(:automatic_changed_method?, color, :will_save_change_to_name?).should == true
+      Color.send(:automatic_changed_method?, color, :will_save_change_to_hex?).should == true
+    end
+
   end
 
 end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #140   <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## Describe your change

We recently made some change to handle the new `will_save_change_to_#{attr}?` instead of the deprecated `#{attr}_changed?`. See #325

I didn't realize that this was breaking backward compat' because we check your ActiveRecord version. So if you upgrade, existing methods named `#{attr}_changed?` won't be called.

I refactored it to the "first responding method", both will be tested, regardless of your Rails version. I added more tests for this.

### `algolia_dirty?` method

I added this in the same PR but it could be removed to merge the fix independantly. I added a method called `algolia_dirty?`, you can define it to override the calls to all  _changed? method. I think this could be useful in case you need to define many _changed? method or to handle multiple relationships.

Please any feedback on this one is appreciated 🙏 

```ruby
class Ebook < ActiveRecord::Base
  include AlgoliaSearch

  algoliasearch :synchronous => true, :index_name => safe_index_name("eBooks")do
    attributesToIndex [:name]
  end

  def algolia_dirty?
    self.author.custom_modified_recently?
  end
end
```

📝 **DOC**: Doc update is one the way.


