### PR TITLE
Use scoped copy index to init tmp indices

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem 'json', '~> 1.8', '>= 1.8.6'
-gem 'algoliasearch', '>= 1.17.0', '< 2.0.0'
+gem 'algoliasearch', '>= 1.26.0', '< 2.0.0'
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
   gem 'rubysl', '~> 2.0', :platform => :rbx

--- a/algoliasearch-rails.gemspec
+++ b/algoliasearch-rails.gemspec
@@ -87,11 +87,11 @@ Gem::Specification.new do |s|
       s.add_development_dependency "rdoc"
     else
       s.add_dependency(%q<json>, [">= 1.5.1"])
-      s.add_dependency(%q<algoliasearch>, [">= 1.17.0", "< 2.0.0"])
+      s.add_dependency(%q<algoliasearch>, [">= 1.26.0", "< 2.0.0"])
     end
   else
     s.add_dependency(%q<json>, [">= 1.5.1"])
-    s.add_dependency(%q<algoliasearch>, [">= 1.17.0", "< 2.0.0"])
+    s.add_dependency(%q<algoliasearch>, [">= 1.26.0", "< 2.0.0"])
   end
 end
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | not sure
| New feature?      | not sure    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | If you want to delete all your synonyms and rules when reindexing, yes
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## Describe your change


When using `Model.reindex`, we create a temporary index and send all records again, then rename (move) it.Settings were set by the Rails app.
Synonyms (in some case) and Rules were lost.

This Rails gem handles synonyms via the settings, which is the old way. Algolia engine handles synonyms separately now.


This PR leverages the copy index scope introduced last year. Which copy settings, synonyms and query rules from the prod index to the temporary one.

Synonyms and rules are preserved when reindexing 🎉

It also allows us to remove some logic about handling replicas, it’s now done in the engine.

**NOTE:** This PR bumps the minimum required Algolia ruby client, make sure you upgrade.