### PR TITLE
Use temporary index to preserve synonmys, settings, and rules

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## [1.23.2](https://github.com/algolia/algoliasearch-rails/releases/tag/1.23.2) (2019-06-26)
+
+**Fixed**
+
+* Use `copy_index` when initiating a temporary index to preserve settings, synonyms, and rules.
+
+
 ## [1.23.0](https://github.com/algolia/algoliasearch-rails/releases/tag/1.23.0) (2019-06-25)
 
 **Added**

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem 'json', '~> 1.8', '>= 1.8.6'
-gem 'algoliasearch', '>= 1.23.0', '< 2.0.0'
+gem 'algoliasearch', '>= 1.26.0', '< 2.0.0'
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
   gem 'rubysl', '~> 2.0', :platform => :rbx

--- a/algoliasearch-rails.gemspec
+++ b/algoliasearch-rails.gemspec
@@ -79,7 +79,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<json>, [">= 1.5.1"])
-      s.add_runtime_dependency(%q<algoliasearch>, [">= 1.23.0", "< 2.0.0"])
+      s.add_runtime_dependency(%q<algoliasearch>, [">= 1.26.0", "< 2.0.0"])
       s.add_development_dependency(%q<will_paginate>, [">= 2.3.15"])
       s.add_development_dependency(%q<kaminari>, [">= 0"])
       s.add_development_dependency "travis"
@@ -87,11 +87,11 @@ Gem::Specification.new do |s|
       s.add_development_dependency "rdoc"
     else
       s.add_dependency(%q<json>, [">= 1.5.1"])
-      s.add_dependency(%q<algoliasearch>, [">= 1.23.0", "< 2.0.0"])
+      s.add_dependency(%q<algoliasearch>, [">= 1.26.0", "< 2.0.0"])
     end
   else
     s.add_dependency(%q<json>, [">= 1.5.1"])
-    s.add_dependency(%q<algoliasearch>, [">= 1.23.0", "< 2.0.0"])
+    s.add_dependency(%q<algoliasearch>, [">= 1.26.0", "< 2.0.0"])
   end
 end
 

--- a/lib/algoliasearch/version.rb
+++ b/lib/algoliasearch/version.rb
@@ -1,3 +1,3 @@
 module AlgoliaSearch
-  VERSION = '1.23.1'
+  VERSION = '1.23.2'
 end


### PR DESCRIPTION
Use temporary index to preserve synonyms, settings, and rules.
Upgrade to latest ruby API clients.