### PR TITLE
Use Zeitwerk for loading models in Rails 6

### DIFF
--- a/lib/algoliasearch/utilities.rb
+++ b/lib/algoliasearch/utilities.rb
@@ -2,7 +2,11 @@ module AlgoliaSearch
   module Utilities
     class << self
       def get_model_classes
-        Rails.application.eager_load! if Rails.application # Ensure all models are loaded (not necessary in production when cache_classes is true).
+        if defined?(Rails.autoloaders) && Rails.autoloaders.zeitwerk_enabled?
+          Zeitwerk::Loader.eager_load_all
+        elsif Rails.application
+          Rails.application.eager_load!
+        end
         AlgoliaSearch.instance_variable_get :@included_in
       end
 


### PR DESCRIPTION
In Rails 6, model loading is no longer working. This is because Zeitwerk has
replaced the original code loading. We now use Zeitwerk if it's available.

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | n/a  <!-- will close issue automatically, if any -->
| Need Doc update   | no


## Describe your change

Fix model loading in Rails 6 when using Zeitwork

## What problem is this fixing?

Model loading doesn't work in Rails 6