### PR TITLE
Prevent an extra get_settings call even if check_settings is false

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -807,12 +807,14 @@ module AlgoliaSearch
 
       @algolia_indexes[settings] = SafeIndex.new(algolia_index_name(options), algoliasearch_options[:raise_on_failure])
 
-      current_settings = @algolia_indexes[settings].get_settings(:getVersion => 1) rescue nil # if the index doesn't exist
-
       index_settings ||= settings.to_settings
       index_settings = options[:primary_settings].to_settings.merge(index_settings) if options[:inherit]
 
       options[:check_settings] = true if options[:check_settings].nil?
+
+      current_settings = if options[:check_settings]
+                           @algolia_indexes[settings].get_settings(:getVersion => 1) rescue nil # if the index doesn't exist
+                         end
 
       if !algolia_indexing_disabled?(options) && options[:check_settings] && algoliasearch_settings_changed?(current_settings, index_settings)
         used_slaves = !current_settings.nil? && !current_settings['slaves'].nil?


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | no
| Need Doc update   | no


## Describe your change

Added condition to check if `check_settings` is `true` before retrieving index settings.

## What problem is this fixing?

An extra call to get index settings performs even if `check_settings` is `false` as it described here https://www.algolia.com/doc/framework-integration/rails/index-configuration/index-settings/?language=ruby#synchronizing-settings
