### PR TITLE
A try to fix builds. Set dist to trusty for Ruby 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
   include:
     - rvm: 1.8.7
       env: RAILS_VERSION=3.2.0 SEQUEL_VERSION=4.0
+      dist: trusty
     - rvm: 1.9.3
       env: RAILS_VERSION=3.2.0
     - rvm: 1.9.3


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | no
| Need Doc update   | no


## Describe your change

Set dist to trusty in .travis.yml

## What problem is this fixing?

Failing builds for Ruby 1.8.7.
