### PR TITLE
Introduce: pass array argument to geoloc

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :test do
     gem 'net-http-persistent', '< 3.0'
   end
   gem 'rspec', '>= 2.5.0', '< 3.0'
-  gem 'sqlite3', '< 1.4.0', :platform => [:rbx, :ruby]
+  gem 'sqlite3', '~> 1.4.0', :platform => [:rbx, :ruby]
   gem 'jdbc-sqlite3', :platform => :jruby
   gem 'activerecord-jdbc-adapter', :platform => :jruby
   gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :test do
     gem 'net-http-persistent', '< 3.0'
   end
   gem 'rspec', '>= 2.5.0', '< 3.0'
-  gem 'sqlite3', '~> 1.4.0', :platform => [:rbx, :ruby]
+  gem 'sqlite3', '< 1.4.0', :platform => [:rbx, :ruby]
   gem 'jdbc-sqlite3', :platform => :jruby
   gem 'activerecord-jdbc-adapter', :platform => :jruby
   gem 'activerecord-jdbcsqlite3-adapter', :platform => :jruby

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -223,10 +223,10 @@ module AlgoliaSearch
       end
     end
 
-    def geoloc(lat_attr, lng_attr)
+    def geoloc(lat_attr = nil, lng_attr = nil, &block)
       raise ArgumentError.new('Cannot specify additional attributes on a replica index') if @options[:slave] || @options[:replica]
       add_attribute :_geoloc do |o|
-        { :lat => o.send(lat_attr).to_f, :lng => o.send(lng_attr).to_f }
+        block_given? ? o.instance_eval(&block) : { :lat => o.send(lat_attr).to_f, :lng => o.send(lng_attr).to_f }
       end
     end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -280,7 +280,7 @@ class City < ActiveRecord::Base
   serialize :gl_array
 
   def geoloc_array
-    lat.present? && lng.present? ? { lat: lat, lng: lng } : gl_array
+    lat.present? && lng.present? ? { :lat => lat, :lng => lng } : gl_array
   end
 
   algoliasearch :synchronous => true, :index_name => safe_index_name("City"), :per_environment => true do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1093,7 +1093,6 @@ describe 'Cities' do
     expect(City.index(safe_index_name('City_replica1')).get_settings['customRanking']).to eq(['asc(a)'])
     expect(City.index(safe_index_name('City_replica2')).get_settings['customRanking']).to eq(['asc(a)', 'desc(c)'])
   end
-
 end
 
 describe "FowardToReplicas" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1093,6 +1093,7 @@ describe 'Cities' do
     expect(City.index(safe_index_name('City_replica1')).get_settings['customRanking']).to eq(['asc(a)'])
     expect(City.index(safe_index_name('City_replica2')).get_settings['customRanking']).to eq(['asc(a)', 'desc(c)'])
   end
+
 end
 
 describe "FowardToReplicas" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -72,6 +72,7 @@ ActiveRecord::Schema.define do
     t.string :country
     t.float :lat
     t.float :lng
+    t.string :gl_array
   end
   create_table :with_slaves do |t|
   end
@@ -276,8 +277,16 @@ index.wait_task index.set_settings({'customRanking' => ['desc(d)']})['taskID']
 class City < ActiveRecord::Base
   include AlgoliaSearch
 
+  serialize :gl_array
+
+  def geoloc_array
+    lat.present? && lng.present? ? { lat: lat, lng: lng } : gl_array
+  end
+
   algoliasearch :synchronous => true, :index_name => safe_index_name("City"), :per_environment => true do
-    geoloc :lat, :lng
+    geoloc do
+      geoloc_array
+    end
     add_attribute :a_null_lat, :a_lng
     customRanking ['desc(b)']
 
@@ -1013,14 +1022,16 @@ describe 'Cities' do
   it "should index geo" do
     sf = City.create :name => 'San Francisco', :country => 'USA', :lat => 37.75, :lng => -122.68
     mv = City.create :name => 'Mountain View', :country => 'No man\'s land', :lat => 37.38, :lng => -122.08
+    sf_and_mv = City.create :name => 'San Francisco & Mountain View', :country => 'Hybrid', :gl_array => [{ :lat => 37.75, :lng => -122.68 }, { :lat => 37.38, :lng => -122.08 }]
     results = City.search('', { :aroundLatLng => "37.33, -121.89", :aroundRadius => 50000 })
-    expect(results.size).to eq(1)
-    results.should include(mv)
+    expect(results.size).to eq(2)
+    results.should include(mv, sf_and_mv)
 
     results = City.search('', { :aroundLatLng => "37.33, -121.89", :aroundRadius => 500000 })
-    expect(results.size).to eq(2)
+    expect(results.size).to eq(3)
     results.should include(mv)
     results.should include(sf)
+    results.should include(sf_and_mv)
   end
 
   it "should be searchable using replica index" do


### PR DESCRIPTION
Previously, only a latitude & longitude couple could be passed to geoloc
Now, a larger set in the array form of:
`[{ lat: x_1, lng: y_1 }, ..., { lat: x_n, lng: y_n }]` can be passed,
through a block as below:
```
geoloc do
  geoloc_array
end
```

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #370
| Need Doc update   | no


## Describe your change

Still accept simple latitude & longitude passing, but also an array of several hashes containing different coordinates.

## What problem is this fixing?

Array passing of multiple latitudes & longitudes.