### PR TITLE
Fix ruby warning 'Proc.new is deprecated'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ matrix:
       env: RAILS_VERSION=5.1 SEQUEL_VERSION=5.0
     - rvm: 2.6.0
       env: RAILS_VERSION=5.2 SEQUEL_VERSION=5.0
+    - rvm: 2.7.0
+      env: RAILS_VERSION=5.2 SEQUEL_VERSION=5.0
 
 before_install:
   - wget http://api-key-dealer.herokuapp.com/clients/algolia-keys && chmod +x algolia-keys

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -92,7 +92,7 @@ module AlgoliaSearch
 
     def initialize(options, &block)
       @options = options
-      instance_exec(&block) if block
+      instance_exec(&block) if block_given?
     end
 
     def use_serializer(serializer)

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -389,7 +389,7 @@ module AlgoliaSearch
     end
 
     def algoliasearch(options = {}, &block)
-      self.algoliasearch_settings = IndexSettings.new(options, block_given? ? Proc.new : nil)
+      self.algoliasearch_settings = IndexSettings.new(options, &block)
       self.algoliasearch_options = { :type => algolia_full_const_get(model_name.to_s), :per_page => algoliasearch_settings.get_setting(:hitsPerPage) || 10, :page => 1 }.merge(options)
 
       attr_accessor :highlight_result, :snippet_result

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -90,7 +90,7 @@ module AlgoliaSearch
       end
     end
 
-    def initialize(options, block)
+    def initialize(options, &block)
       @options = options
       instance_exec(&block) if block
     end

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -272,7 +272,7 @@ module AlgoliaSearch
       @additional_indexes ||= {}
       raise MixedSlavesAndReplicas.new('Cannot mix slaves and replicas in the same configuration (add_slave is deprecated)') if (options[:slave] && @additional_indexes.any? { |opts, _| opts[:replica] }) || (options[:replica] && @additional_indexes.any? { |opts, _| opts[:slave] })
       options[:index_name] = index_name
-      @additional_indexes[options] = IndexSettings.new(options, Proc.new)
+      @additional_indexes[options] = IndexSettings.new(options, &block)
     end
 
     def add_replica(index_name, options = {}, &block)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -538,7 +538,7 @@ unless OLD_RAILS
       Color.delete_all
     end
 
-    it "Throw an exception if the data is too big" do
+    it "should throw an exception if the data is too big" do
       expect {
         Color.create! :name => 'big' * 100000
       }.to raise_error(Algolia::AlgoliaProtocolError)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #376
| Need Doc update   | no


## Describe your change

- Ruby 2.7 compatibility (warning fix)
- Rename test naming using convention `it should` prefix

## What problem is this fixing?

Fix `/usr/local/bundle/ruby/2.7.0/gems/algoliasearch-rails-1.23.2/lib/algoliasearch-rails.rb:392: warning: Capturing the given block using Proc.new is deprecated; use `&block` instead` warning on ruby 2.7
