### PR TITLE
Return the request object when calling index! rather than nil

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -614,7 +614,7 @@ module AlgoliaSearch
 
     def algolia_index!(object, synchronous = false)
       return if algolia_without_auto_index_scope
-      algolia_configurations.each do |options, settings|
+      algolia_configurations.map do |options, settings|
         next if algolia_indexing_disabled?(options)
         object_id = algolia_object_id_of(object, options)
         index = algolia_ensure_init(options, settings)
@@ -635,7 +635,6 @@ module AlgoliaSearch
           end
         end
       end
-      nil
     end
 
     def algolia_remove_from_index!(object, synchronous = false)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Need Doc update   | no


## Describe your change

This gives access to the Algolia request (including the taskID) when using the Rails API (eg object.index!).

## What problem is this fixing?

This is useful when we want to check the status of a task after indexing an object and when the synchronous API is not suitable to our needs.