### PR TITLE
add indexLanguages option handler

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -68,7 +68,7 @@ module AlgoliaSearch
       :disableTypoToleranceOnAttributes, :disableTypoToleranceOnWords, :separatorsToIndex,
       # Language
       :ignorePlurals, :removeStopWords, :camelCaseAttributes, :decompoundedAttributes,
-      :keepDiacriticsOnCharacters, :queryLanguages,
+      :keepDiacriticsOnCharacters, :queryLanguages, :indexLanguages,
       # Query Rules
       :enableRules,
       # Query Strategy


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | -
| Need Doc update   | no


## Describe your change

This code append indexLanguages option management ability.

## What problem is this fixing?

Currently, we cannot manage indexLanguages option via Rails codes.
