### PR TITLE
Include ActiveModel::Serializer associations

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -161,7 +161,7 @@ module AlgoliaSearch
       # If a serializer is set, we ignore attributes
       # everything should be done via the serializer
       if not @serializer.nil?
-        attributes = @serializer.new(object).attributes
+        attributes = @serializer.new(object).as_json
       else
         if @attributes.nil? || @attributes.length == 0
           # no `attribute ...` have been configured, use the default attributes of the model

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -482,7 +482,29 @@ end
 
 if defined?(ActiveModel::Serializer)
   class SerializedObjectSerializer < ActiveModel::Serializer
+    belongs_to :serialized_association_object
     attributes :name
+
+    def serialized_association_object
+      SerializedAssociationObject.new :name => 'test-association'
+    end
+  end
+
+  class SerializedAssociationObjectSerializer < ActiveModel::Serializer
+    attributes :name
+  end
+
+  class SerializedAssociationObject
+    alias :read_attribute_for_serialization :send
+    attr_accessor :name
+
+    def initialize(attributes)
+      @name = attributes[:name]
+    end
+
+    def self.model_name
+      @_model_name ||= ActiveModel::Name.new(self)
+    end
   end
 
   class SerializedObject < ActiveRecord::Base
@@ -507,7 +529,7 @@ if defined?(ActiveModel::Serializer)
     it "should push the name but not the other attribute" do
       o = SerializedObject.new :name => 'test', :skip => 'skip me'
       attributes = SerializedObject.algoliasearch_settings.get_attributes(o)
-      expect(attributes).to eq({:name => 'test', "_tags" => ['tag1', 'tag2']})
+      expect(attributes).to eq({:name => 'test', "_tags" => ['tag1', 'tag2'], :audio_files => {:name => 'test-association'}})
     end
   end
 end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #346 
| Need Doc update   | no


## Describe your change

Calling the `attributes` method on an instance of a `ActiveModel::Serializer` class does not include associations. This fixes the issue by calling the `as_json` method instead. 

## What problem is this fixing?

When using an ActiveModel Serializer to serialize your model, associations are not included.