### PR TITLE
fix(reindex): merge of settings in reindex method

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -561,14 +561,10 @@ module AlgoliaSearch
         tmp_options.delete(:per_environment) # already included in the temporary index_name
         tmp_settings = settings.dup
 
-        if options[:check_settings] == false
-          ::Algolia::copy_index!(src_index_name, tmp_index_name, %w(settings synonyms rules))
-          tmp_index = SafeIndex.new(tmp_index_name, !!options[:raise_on_failure])
-        else
-          tmp_index = algolia_ensure_init(tmp_options, tmp_settings, master_settings)
-        end
+        ::Algolia::copy_index!(src_index_name, tmp_index_name, %w(settings synonyms rules))
+        tmp_index = SafeIndex.new(tmp_index_name, !!options[:raise_on_failure])
 
-          algolia_find_in_batches(batch_size) do |group|
+        algolia_find_in_batches(batch_size) do |group|
           if algolia_conditional_index?(options)
             # select only indexable objects
             group = group.select { |o| algolia_indexable?(o, tmp_options) }

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -823,6 +823,11 @@ describe 'Colors' do
     expect(facets.first['highlighted']).to eq('<em>bl</em>a')
     expect(facets.first['count']).to eq(1)
   end
+
+  it "should reindex after settings change" do
+    Color.index.set_settings!(:searchableAttributes => [:short_name])
+    Color.reindex
+  end
 end
 
 describe 'An imaginary store' do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -826,7 +826,7 @@ describe 'Colors' do
 
   it "should reindex after settings change" do
     Color.index.set_settings!(:searchableAttributes => [:short_name])
-    Color.reindex
+    expect { Color.reindex }.to_not raise_error
   end
 end
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #357
| Need Doc update   | no


## Describe your change

In the `reindex` method, when using a tmp index, base configuration of the index was copied regardless of changes that could have been made, causing an error especially if the deprecated `attributesToIndex` parameter was used. This fixes this issue.