### PR TITLE
fix(tests): fix check of autoloaders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ matrix:
       env: RAILS_VERSION=6.0 SEQUEL_VERSION=5.0
 
 before_install:
-  - wget http://api-key-dealer.herokuapp.com/clients/algolia-keys && chmod +x algolia-keys
   - which bundle || true
   - find /home/travis/.rvm -wholename "*/bundler-*.gemspec" -print -delete || true
   - bundle --version || true
@@ -59,4 +58,4 @@ install: rm -f Gemfile.lock && bundle install --without development
 cache: bundler
 
 script:
-  - eval $(./algolia-keys export) && bundle exec rake
+  - bundle exec rake

--- a/lib/algoliasearch/utilities.rb
+++ b/lib/algoliasearch/utilities.rb
@@ -2,7 +2,7 @@ module AlgoliaSearch
   module Utilities
     class << self
       def get_model_classes
-        if defined?(Rails.autoloaders) && Rails.autoloaders.zeitwerk_enabled?
+        if Rails.application && defined?(Rails.autoloaders) && Rails.autoloaders.zeitwerk_enabled?
           Zeitwerk::Loader.eager_load_all
         elsif Rails.application
           Rails.application.eager_load!


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fix #393
| Need Doc update   | no


## Describe your change

In order for the app to be able to use Zeitwerk autoloading, a fix was made in the class loader. However, as the condition did not check if application was running before anything else, it triggered a `undefined method `config' for nil:NilClass` on `Rails.application`. We now check first that the application is correctly running before making use of autoloading

This fixes the [failing CI for Rails 6](https://app.circleci.com/pipelines/github/algolia/algoliasearch-rails/20/workflows/3fc49ccc-edae-4487-8675-e60adb886a17/jobs/461) 