### PR TITLE
fix ruby 3.0 default splat behavior

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ aliases:
   - &credentials
     name: Retrieve temporary Algolia credentials if needed
     command: |
-      if [ -z "ALGOLIA_ADMIN_KEY_MCM" ]; then
+      if [ "$CIRCLE_PR_REPONAME" ]; then
         curl -s https://algoliasearch-client-keygen.herokuapp.com | sh >> $BASH_ENV
       fi
 
@@ -44,64 +44,7 @@ references:
 version: 2.1
 
 jobs:
-  tests_rails_3:
-    description: Build, unit and integration tests
-    parameters:
-      version:
-        type: string
-      rails-version:
-        type: string
-      sequel-version:
-        type: string
-    docker:
-      - *default_docker_ruby_executor
-    steps:
-      - checkout
-      - run: *check_bundler
-      - restore_cache: *restore_cache
-      - run: *install_bundler
-      - save_cache: *save_cache
-      - run: *credentials
-      - run: *run_tests
-  tests_rails_4:
-    description: Build, unit and integration tests
-    parameters:
-      version:
-        type: string
-      rails-version:
-        type: string
-      sequel-version:
-        type: string
-    docker:
-      - *default_docker_ruby_executor
-    steps:
-      - checkout
-      - run: *check_bundler
-      - restore_cache: *restore_cache
-      - run: *install_bundler
-      - save_cache: *save_cache
-      - run: *credentials
-      - run: *run_tests
-  tests_rails_5:
-    description: Build, unit and integration tests
-    parameters:
-      version:
-        type: string
-      rails-version:
-        type: string
-      sequel-version:
-        type: string
-    docker:
-      - *default_docker_ruby_executor
-    steps:
-      - checkout
-      - run: *check_bundler
-      - restore_cache: *restore_cache
-      - run: *install_bundler
-      - save_cache: *save_cache
-      - run: *credentials
-      - run: *run_tests
-  tests_rails_6:
+  test:
     description: Build, unit and integration tests
     parameters:
       version:
@@ -125,21 +68,46 @@ workflows:
   version: 2
   ci:
     jobs:
-      - tests_rails_4:
-          matrix:
-            parameters:
-              version: ['2.2', '2.3', '2.4']
-              rails-version: ['4.2']
-              sequel-version: ['4.0']
-      - tests_rails_5:
-          matrix:
-            parameters:
-              version: ['2.2', '2.3', '2.4', '2.5', '2.6', '2.7']
-              rails-version: ['5.1']
-              sequel-version: ['4.0', '5.0']
-      - tests_rails_6:
-          matrix:
-            parameters:
-              version: ['2.5', '2.6', '2.7']
-              rails-version: ['6.0']
-              sequel-version: ['4.0', '5.0']
+      - test:
+          name: 'Rails 5.1 - Ruby 2.4'
+          version: '2.4'
+          rails-version: '5.1'
+          sequel-version: '5.0'
+      - test:
+          name: 'Rails 5.1 - Ruby 2.5'
+          version: '2.5'
+          rails-version: '5.1'
+          sequel-version: '5.0'
+      - test:
+          name: 'Rails 5.1 - Ruby 2.6'
+          version: '2.6'
+          rails-version: '5.1'
+          sequel-version: '5.0'
+
+
+      - test:
+          name: 'Rails 6.0 - Ruby 2.5'
+          version: '2.5'
+          rails-version: '6.0'
+          sequel-version: '5.0'
+      - test:
+          name: 'Rails 6.0 - Ruby 2.6'
+          version: '2.6'
+          rails-version: '6.0'
+          sequel-version: '5.0'
+      - test:
+          name: 'Rails 6.0 - Ruby 2.7'
+          version: '2.7'
+          rails-version: '6.0'
+          sequel-version: '5.0'
+
+      - test:
+          name: 'Rails 6.1 - Ruby 2.7'
+          version: '2.7'
+          rails-version: '6.1'
+          sequel-version: '5.0'
+      - test:
+          name: 'Rails 6.1 - Ruby 3.0'
+          version: '3.0'
+          rails-version: '6.1'
+          sequel-version: '5.0'

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ rdoc
 pkg
 .rvmrc
 Gemfile.lock
+debug.log
+.ruby-version
 
 ## PROJECT::SPECIFIC
 data.sqlite3

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,13 @@
 # CHANGELOG
 
-## [Unreleased](https://github.com/algolia/algoliasearch-rails/compare/1.25.0...master)
+## [Unreleased](https://github.com/algolia/algoliasearch-rails/compare/2.0.0...master)
+
+## [2.0.0](https://github.com/algolia/algoliasearch-rails/compare/2.0.0...1.25.0)
+
+### Breaking changes
+- Adds support for `algolia` gem.
+- Drops support for Ruby < 2.4
+- Drops support for Rails < 5.1
 
 ## [1.25.0](https://github.com/algolia/algoliasearch-rails/compare/1.24.1...1.25.0) (2020-11-24)
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,39 +1,16 @@
 source "http://rubygems.org"
 
-gem 'json', '~> 1.8', '>= 1.8.6'
-gem 'algoliasearch', '>= 1.26.0', '< 2.0.0'
+gem 'json', '>= 1.5.1'
+gem 'algolia', '< 3.0.0'
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
   gem 'rubysl', '~> 2.0', :platform => :rbx
 end
 
 group :test do
-  rails_version = ENV["RAILS_VERSION"] || '5.2'
+  rails_version = ENV["RAILS_VERSION"] || '6.1'
   gem 'rails', "~> #{rails_version}"
   gem 'active_model_serializers'
-  if defined?(RUBY_VERSION) && RUBY_VERSION == "1.8.7"
-    gem 'i18n', '< 0.7'
-    gem 'highline', '< 1.7'
-    gem 'addressable', '<= 2.2.7'
-    gem 'rack-cache', '< 1.3'
-    gem 'mime-types', '< 2.6'
-    gem 'net-http-persistent', '< 3.0'
-    gem 'faraday', '< 0.10'
-  elsif defined?(RUBY_VERSION) && RUBY_VERSION == "1.9.3"
-    gem 'rack', '< 2'
-    gem 'rack-cache', '<= 1.7.1'
-    if Gem::Version.new(ENV['RAILS_VERSION'] || '3.2.0') >= Gem::Version.new('4.0')
-      gem 'mime-types', '~> 2.6'
-    else
-      gem 'mime-types', '< 3'
-    end
-  end
-  if defined?(RUBY_VERSION) &&
-     defined?(RUBY_ENGINE) &&
-     RUBY_ENGINE == 'ruby' &&
-     Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.1')
-    gem 'net-http-persistent', '< 3.0'
-  end
   if Gem::Version.new(rails_version) >= Gem::Version.new('6.0')
     gem 'sqlite3', '~> 1.4.0', :platform => [:rbx, :ruby]
   else
@@ -57,13 +34,6 @@ end
 
 group :test, :development do
   gem 'will_paginate', '>= 2.3.15'
-  if defined?(RUBY_VERSION) &&
-     defined?(RUBY_ENGINE) &&
-     RUBY_ENGINE == 'ruby' &&
-     Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2')
-    gem 'kaminari', '< 1'
-  else
-    gem 'kaminari'
-  end
+  gem 'kaminari', '< 1'
 end
 

--- a/algoliasearch-rails.gemspec
+++ b/algoliasearch-rails.gemspec
@@ -79,7 +79,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<json>, [">= 1.5.1"])
-      s.add_runtime_dependency(%q<algoliasearch>, [">= 1.26.0", "< 2.0.0"])
+      s.add_runtime_dependency(%q<algolia>, ["< 3.0.0"])
       s.add_development_dependency(%q<will_paginate>, [">= 2.3.15"])
       s.add_development_dependency(%q<kaminari>, [">= 0"])
       s.add_development_dependency "travis"
@@ -87,11 +87,11 @@ Gem::Specification.new do |s|
       s.add_development_dependency "rdoc"
     else
       s.add_dependency(%q<json>, [">= 1.5.1"])
-      s.add_dependency(%q<algoliasearch>, [">= 1.26.0", "< 2.0.0"])
+      s.add_dependency(%q<algolia>, ["< 3.0.0"])
     end
   else
     s.add_dependency(%q<json>, [">= 1.5.1"])
-    s.add_dependency(%q<algoliasearch>, [">= 1.26.0", "< 2.0.0"])
+    s.add_dependency(%q<algolia>, ["< 3.0.0"])
   end
 end
 

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -1,4 +1,4 @@
-require 'algoliasearch'
+require 'algolia'
 
 require 'algoliasearch/version'
 require 'algoliasearch/utilities'
@@ -53,7 +53,6 @@ module AlgoliaSearch
     OPTIONS = [
       # Attributes
       :searchableAttributes, :attributesForFaceting, :unretrievableAttributes, :attributesToRetrieve,
-      :attributesToIndex, #Legacy name of searchableAttributes
       # Ranking
       :ranking, :customRanking, # Replicas are handled via `add_replica`
       # Faceting
@@ -76,7 +75,6 @@ module AlgoliaSearch
       :disablePrefixOnAttributes, :disableExactOnAttributes, :exactOnSingleWordQuery, :alternativesAsExact,
       # Performance
       :numericAttributesForFiltering, :allowCompressionOfIntegerArray,
-      :numericAttributesToIndex, # Legacy name of numericAttributesForFiltering
       # Advanced
       :attributeForDistinct, :distinct, :replaceSynonymsInHighlight, :minProximity, :responseFields,
       :maxFacetHits,
@@ -102,7 +100,7 @@ module AlgoliaSearch
 
     def attribute(*names, &block)
       raise ArgumentError.new('Cannot pass multiple attribute names if block given') if block_given? and names.length > 1
-      raise ArgumentError.new('Cannot specify additional attributes on a replica index') if @options[:slave] || @options[:replica]
+      raise ArgumentError.new('Cannot specify additional attributes on a replica index') if @options[:replica]
       @attributes ||= {}
       names.flatten.each do |name|
         @attributes[name.to_s] = block_given? ? Proc.new { |o| o.instance_eval(&block) } : Proc.new { |o| o.send(name) }
@@ -112,7 +110,7 @@ module AlgoliaSearch
 
     def add_attribute(*names, &block)
       raise ArgumentError.new('Cannot pass multiple attribute names if block given') if block_given? and names.length > 1
-      raise ArgumentError.new('Cannot specify additional attributes on a replica index') if @options[:slave] || @options[:replica]
+      raise ArgumentError.new('Cannot specify additional attributes on a replica index') if @options[:replica]
       @additional_attributes ||= {}
       names.each do |name|
         @additional_attributes[name.to_s] = block_given? ? Proc.new { |o| o.instance_eval(&block) } : Proc.new { |o| o.send(name) }
@@ -224,14 +222,14 @@ module AlgoliaSearch
     end
 
     def geoloc(lat_attr = nil, lng_attr = nil, &block)
-      raise ArgumentError.new('Cannot specify additional attributes on a replica index') if @options[:slave] || @options[:replica]
+      raise ArgumentError.new('Cannot specify additional attributes on a replica index') if @options[:replica]
       add_attribute :_geoloc do |o|
         block_given? ? o.instance_eval(&block) : { :lat => o.send(lat_attr).to_f, :lng => o.send(lng_attr).to_f }
       end
     end
 
     def tags(*args, &block)
-      raise ArgumentError.new('Cannot specify additional attributes on a replica index') if @options[:slave] || @options[:replica]
+      raise ArgumentError.new('Cannot specify additional attributes on a replica index') if @options[:replica]
       add_attribute :_tags do |o|
         v = block_given? ? o.instance_eval(&block) : args
         v.is_a?(Array) ? v : [v]
@@ -248,13 +246,7 @@ module AlgoliaSearch
         v = get_setting(k)
         settings[k] = v if !v.nil?
       end
-      if !@options[:slave] && !@options[:replica]
-        settings[:slaves] = additional_indexes.select { |opts, s| opts[:slave] }.map do |opts, s|
-          name = opts[:index_name]
-          name = "#{name}_#{Rails.env.to_s}" if opts[:per_environment]
-          name
-        end
-        settings.delete(:slaves) if settings[:slaves].empty?
+      if !@options[:replica]
         settings[:replicas] = additional_indexes.select { |opts, s| opts[:replica] }.map do |opts, s|
           name = opts[:index_name]
           name = "#{name}_#{Rails.env.to_s}" if opts[:per_environment]
@@ -266,25 +258,18 @@ module AlgoliaSearch
     end
 
     def add_index(index_name, options = {}, &block)
-      raise ArgumentError.new('Cannot specify additional index on a replica index') if @options[:slave] || @options[:replica]
+      raise ArgumentError.new('Cannot specify additional index on a replica index') if @options[:replica]
       raise ArgumentError.new('No block given') if !block_given?
       raise ArgumentError.new('Options auto_index and auto_remove cannot be set on nested indexes') if options[:auto_index] || options[:auto_remove]
       @additional_indexes ||= {}
-      raise MixedSlavesAndReplicas.new('Cannot mix slaves and replicas in the same configuration (add_slave is deprecated)') if (options[:slave] && @additional_indexes.any? { |opts, _| opts[:replica] }) || (options[:replica] && @additional_indexes.any? { |opts, _| opts[:slave] })
       options[:index_name] = index_name
       @additional_indexes[options] = IndexSettings.new(options, &block)
     end
 
     def add_replica(index_name, options = {}, &block)
-      raise ArgumentError.new('Cannot specify additional replicas on a replica index') if @options[:slave] || @options[:replica]
+      raise ArgumentError.new('Cannot specify additional replicas on a replica index') if @options[:replica]
       raise ArgumentError.new('No block given') if !block_given?
       add_index(index_name, options.merge({ :replica => true, :primary_settings => self }), &block)
-    end
-
-    def add_slave(index_name, options = {}, &block)
-      raise ArgumentError.new('Cannot specify additional slaves on a slave index') if @options[:slave] || @options[:replica]
-      raise ArgumentError.new('No block given') if !block_given?
-      add_index(index_name, options.merge({ :slave => true, :primary_settings => self }), &block)
     end
 
     def additional_indexes
@@ -304,11 +289,11 @@ module AlgoliaSearch
   # are correctly logged or thrown depending on the `raise_on_failure` option
   class SafeIndex
     def initialize(name, raise_on_failure)
-      @index = ::Algolia::Index.new(name)
+      @index = AlgoliaSearch.client.init_index(name)
       @raise_on_failure = raise_on_failure.nil? || raise_on_failure
     end
 
-    ::Algolia::Index.instance_methods(false).each do |m|
+    ::Algolia::Search::Index.instance_methods(false).each do |m|
       define_method(m) do |*args, &block|
         SafeIndex.log_or_throw(m, @raise_on_failure) do
           @index.send(m, *args, &block)
@@ -329,7 +314,7 @@ module AlgoliaSearch
       SafeIndex.log_or_throw(:get_settings, @raise_on_failure) do
         begin
           @index.get_settings(*args)
-        rescue Algolia::AlgoliaError => e
+        rescue Algolia::AlgoliaHttpError => e
           return {} if e.code == 404 # not fatal
           raise e
         end
@@ -339,7 +324,7 @@ module AlgoliaSearch
     # expose move as well
     def self.move_index(old_name, new_name)
       SafeIndex.log_or_throw(:move_index, true) do
-        ::Algolia.move_index(old_name, new_name)
+        AlgoliaSearch.client.move_index(old_name, new_name)
       end
     end
 
@@ -511,7 +496,7 @@ module AlgoliaSearch
       algolia_configurations.each do |options, settings|
         next if algolia_indexing_disabled?(options)
         index = algolia_ensure_init(options, settings)
-        next if options[:slave] || options[:replica]
+        next if options[:replica]
         last_task = nil
 
         algolia_find_in_batches(batch_size) do |group|
@@ -531,7 +516,7 @@ module AlgoliaSearch
           end
           last_task = index.save_objects(objects)
         end
-        index.wait_task(last_task["taskID"]) if last_task and (synchronous || options[:synchronous])
+        index.wait_task(last_task.raw_response["taskID"]) if last_task and (synchronous || options[:synchronous])
       end
       nil
     end
@@ -541,7 +526,7 @@ module AlgoliaSearch
       return if algolia_without_auto_index_scope
       algolia_configurations.each do |options, settings|
         next if algolia_indexing_disabled?(options)
-        next if options[:slave] || options[:replica]
+        next if options[:replica]
 
         # fetch the master settings
         master_index = algolia_ensure_init(options, settings)
@@ -549,8 +534,6 @@ module AlgoliaSearch
         master_settings.merge!(JSON.parse(settings.to_settings.to_json)) # convert symbols to strings
 
         # remove the replicas of the temporary index
-        master_settings.delete :slaves
-        master_settings.delete 'slaves'
         master_settings.delete :replicas
         master_settings.delete 'replicas'
 
@@ -562,7 +545,7 @@ module AlgoliaSearch
         tmp_settings = settings.dup
 
         if options[:check_settings] == false
-          ::Algolia::copy_index!(src_index_name, tmp_index_name, %w(settings synonyms rules))
+          @client.copy_index!(src_index_name, tmp_index_name, %w(settings synonyms rules))
           tmp_index = SafeIndex.new(tmp_index_name, !!options[:raise_on_failure])
         else
           tmp_index = algolia_ensure_init(tmp_options, tmp_settings, master_settings)
@@ -578,7 +561,7 @@ module AlgoliaSearch
         end
 
         move_task = SafeIndex.move_index(tmp_index.name, src_index_name)
-        master_index.wait_task(move_task["taskID"]) if synchronous || options[:synchronous]
+        master_index.wait_task(move_task.raw_response["taskID"]) if synchronous || options[:synchronous]
       end
       nil
     end
@@ -587,8 +570,6 @@ module AlgoliaSearch
       algolia_configurations.each do |options, settings|
         if options[:primary_settings] && options[:inherit]
           primary = options[:primary_settings].to_settings
-          primary.delete :slaves
-          primary.delete 'slaves'
           primary.delete :replicas
           primary.delete 'replicas'
           final_settings = primary.merge(settings.to_settings)
@@ -598,7 +579,7 @@ module AlgoliaSearch
 
         index = SafeIndex.new(algolia_index_name(options), true)
         task = index.set_settings(final_settings)
-        index.wait_task(task["taskID"]) if synchronous
+        index.wait_task(task.raw_response["taskID"]) if synchronous
       end
     end
 
@@ -606,9 +587,9 @@ module AlgoliaSearch
       algolia_configurations.each do |options, settings|
         next if algolia_indexing_disabled?(options)
         index = algolia_ensure_init(options, settings)
-        next if options[:slave] || options[:replica]
+        next if options[:replica]
         task = index.save_objects(objects.map { |o| settings.get_attributes(o).merge 'objectID' => algolia_object_id_of(o, options) })
-        index.wait_task(task["taskID"]) if synchronous || options[:synchronous]
+        index.wait_task(task.raw_response["taskID"]) if synchronous || options[:synchronous]
       end
     end
 
@@ -618,13 +599,13 @@ module AlgoliaSearch
         next if algolia_indexing_disabled?(options)
         object_id = algolia_object_id_of(object, options)
         index = algolia_ensure_init(options, settings)
-        next if options[:slave] || options[:replica]
+        next if options[:replica]
         if algolia_indexable?(object, options)
           raise ArgumentError.new("Cannot index a record with a blank objectID") if object_id.blank?
           if synchronous || options[:synchronous]
-            index.add_object!(settings.get_attributes(object), object_id)
+            index.save_object!(settings.get_attributes(object).merge 'objectID' => algolia_object_id_of(object, options))
           else
-            index.add_object(settings.get_attributes(object), object_id)
+            index.save_object(settings.get_attributes(object).merge 'objectID' => algolia_object_id_of(object, options))
           end
         elsif algolia_conditional_index?(options) && !object_id.blank?
           # remove non-indexable objects
@@ -645,7 +626,7 @@ module AlgoliaSearch
       algolia_configurations.each do |options, settings|
         next if algolia_indexing_disabled?(options)
         index = algolia_ensure_init(options, settings)
-        next if options[:slave] || options[:replica]
+        next if options[:replica]
         if synchronous || options[:synchronous]
           index.delete_object!(object_id)
         else
@@ -659,8 +640,8 @@ module AlgoliaSearch
       algolia_configurations.each do |options, settings|
         next if algolia_indexing_disabled?(options)
         index = algolia_ensure_init(options, settings)
-        next if options[:slave] || options[:replica]
-        synchronous || options[:synchronous] ? index.clear! : index.clear
+        next if options[:replica]
+        synchronous || options[:synchronous] ? index.clear_objects! : index.clear_objects
         @algolia_indexes[settings] = nil
       end
       nil
@@ -669,8 +650,6 @@ module AlgoliaSearch
     def algolia_raw_search(q, params = {})
       index_name = params.delete(:index) ||
                    params.delete('index') ||
-                   params.delete(:slave) ||
-                   params.delete('slave') ||
                    params.delete(:replica) ||
                    params.delete('replica')
       index = algolia_index(index_name)
@@ -735,13 +714,11 @@ module AlgoliaSearch
     def algolia_search_for_facet_values(facet, text, params = {})
       index_name = params.delete(:index) ||
                    params.delete('index') ||
-                   params.delete(:slave) ||
-                   params.delete('slave') ||
                    params.delete(:replica) ||
                    params.delete('replicas')
       index = algolia_index(index_name)
       query = Hash[params.map { |k, v| [k.to_s, v.to_s] }]
-      index.search_facet(facet, text, query)['facetHits']
+      index.search_for_facet_values(facet, text, query)['facetHits']
     end
 
     # deprecated (renaming)
@@ -770,7 +747,7 @@ module AlgoliaSearch
       # Loop over each index to see if a attribute used in records has changed
       algolia_configurations.each do |options, settings|
         next if algolia_indexing_disabled?(options)
-        next if options[:slave] || options[:replica]
+        next if options[:replica]
         return true if algolia_object_id_changed?(object, options)
         settings.get_attribute_names(object).each do |k|
           return true if algolia_attribute_changed?(object, k)
@@ -815,13 +792,10 @@ module AlgoliaSearch
       options[:check_settings] = true if options[:check_settings].nil?
 
       if !algolia_indexing_disabled?(options) && options[:check_settings] && algoliasearch_settings_changed?(current_settings, index_settings)
-        used_slaves = !current_settings.nil? && !current_settings['slaves'].nil?
         replicas = index_settings.delete(:replicas) ||
-                   index_settings.delete('replicas') ||
-                   index_settings.delete(:slaves) ||
-                   index_settings.delete('slaves')
-        index_settings[used_slaves ? :slaves : :replicas] = replicas unless replicas.nil? || options[:inherit]
-        @algolia_indexes[settings].set_settings(index_settings)
+                   index_settings.delete('replicas')
+        index_settings[:replicas] = replicas unless replicas.nil? || options[:inherit]
+        @algolia_indexes[settings].set_settings!(index_settings)
       end
 
       @algolia_indexes[settings]

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -246,10 +246,12 @@ module AlgoliaSearch
         v = get_setting(k)
         settings[k] = v if !v.nil?
       end
+
       if !@options[:replica]
         settings[:replicas] = additional_indexes.select { |opts, s| opts[:replica] }.map do |opts, s|
           name = opts[:index_name]
           name = "#{name}_#{Rails.env.to_s}" if opts[:per_environment]
+          name = "virtual(#{name})" if opts[:virtual]
           name
         end
         settings.delete(:replicas) if settings[:replicas].empty?

--- a/lib/algoliasearch/configuration.rb
+++ b/lib/algoliasearch/configuration.rb
@@ -1,14 +1,29 @@
 module AlgoliaSearch
   module Configuration
+    def initiliaze
+      @client = nil
+    end
+
     def configuration
       @@configuration || raise(NotConfigured, "Please configure AlgoliaSearch. Set AlgoliaSearch.configuration = {application_id: 'YOUR_APPLICATION_ID', api_key: 'YOUR_API_KEY'}")
     end
 
     def configuration=(configuration)
       @@configuration = configuration.merge(
-          :user_agent => "Algolia for Rails (#{AlgoliaSearch::VERSION}); Rails (#{Rails::VERSION::STRING})"
+        :user_agent => "Algolia for Rails (#{AlgoliaSearch::VERSION}); Rails (#{Rails::VERSION::STRING})"
       )
-      Algolia.init @@configuration
+    end
+
+    def client
+      if @client.nil?
+        setup_client
+      end
+
+      @client
+    end
+
+    def setup_client
+      @client = Algolia::Search::Client.create_with_config(Algolia::Search::Config.new(@@configuration))
     end
   end
 end

--- a/lib/algoliasearch/pagination/kaminari.rb
+++ b/lib/algoliasearch/pagination/kaminari.rb
@@ -9,7 +9,7 @@ module AlgoliaSearch
     class Kaminari < ::Kaminari::PaginatableArray
 
       def initialize(array, options)
-        super(array, options)
+        super(array, **options)
       end
 
       def limit(num)

--- a/lib/algoliasearch/version.rb
+++ b/lib/algoliasearch/version.rb
@@ -1,3 +1,3 @@
 module AlgoliaSearch
-  VERSION = '1.25.0'
+  VERSION = '2.0.0'
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -111,6 +111,9 @@ ActiveRecord::Schema.define do
   create_table :sub_replicas do |t|
     t.string :name
   end
+  create_table :virtual_replicas do |t|
+    t.string :name
+  end
   create_table :enqueued_objects do |t|
     t.string :name
   end
@@ -436,6 +439,19 @@ class SubReplicas < ActiveRecord::Base
         searchableAttributes ['name']
         customRanking ["desc(name)"]
       end
+    end
+  end
+end
+
+class VirtualReplicas < ActiveRecord::Base
+  include AlgoliaSearch
+
+  algoliasearch :synchronous => true, :force_utf8_encoding => true, :index_name => safe_index_name("VirtualReplica_primary") do
+    searchableAttributes [:name]
+    customRanking ["asc(name)"]
+
+    add_replica safe_index_name("VirtualReplica_replica"), virtual: true do
+      customRanking ["desc(name)"]
     end
   end
 end
@@ -1183,6 +1199,25 @@ describe "SubReplicas" do
 
   it "should be searchable through added indexes replica" do
     expect { SubReplicas.raw_search('something', :index => safe_index_name('Replica_Index')) }.not_to raise_error
+  end
+end
+
+describe "VirtualReplicas" do
+  before(:all) do
+    VirtualReplicas.clear_index!(true)
+  end
+
+  it "setup the replica" do
+    VirtualReplicas.send(:algolia_configurations).to_a.each do |v|
+      if v[0][:replica]
+        expect(v[0][:index_name]).to eq(safe_index_name("VirtualReplica_replica"))
+        expect(v[0][:virtual]).to eq(true)
+        expect(v[1].to_settings[:replicas]).to be_nil
+      else
+        expect(v[0][:index_name]).to eq(safe_index_name("VirtualReplica_primary"))
+        expect(v[1].to_settings[:replicas]).to match_array(["virtual(#{safe_index_name("VirtualReplica_replica")})"])
+      end
+    end
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,8 +29,9 @@ RSpec.configure do |c|
 
   # Remove all indexes setup in this run in local or CI
   c.after(:suite) do
-    safe_index_list.each do |index|
-      Algolia.client.delete_index!(index['name'])
+    safe_index_list.each do |i|
+      index = AlgoliaSearch.client.init_index(i['name'])
+      index.delete!
     end
   end
 end
@@ -45,7 +46,7 @@ end
 
 # get a list of safe indexes in local or CI
 def safe_index_list
-  list = Algolia.client.list_indexes()['items']
+  list = AlgoliaSearch.client.list_indexes['items']
   list = list.select { |index| index["name"].include?(SAFE_INDEX_PREFIX) }
   list.sort_by { |index| index["primary"] || "" }
 end

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -1,6 +1,6 @@
 require File.expand_path(File.join(File.dirname(__FILE__), 'spec_helper'))
 
-AlgoliaSearch.configuration = { :application_id => ENV['ALGOLIA_APPLICATION_ID'], :api_key => ENV['ALGOLIA_API_KEY'] }
+AlgoliaSearch.configuration = { :application_id => ENV['ALGOLIA_APPLICATION_ID'], :api_key => ENV['ALGOLIA_API_KEY'], :symbolize_keys => false }
 
 describe AlgoliaSearch::Utilities do
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      |no    
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   |no


## Describe your change

Ruby 3.0 will not splat arguments on default

## What problem is this fixing?

wrong number of arguments (given 2, expected 0..1)
