### PR TITLE
fix ruby 3.0 default splat behavior

### DIFF
--- a/lib/algoliasearch/pagination/kaminari.rb
+++ b/lib/algoliasearch/pagination/kaminari.rb
@@ -9,7 +9,7 @@ module AlgoliaSearch
     class Kaminari < ::Kaminari::PaginatableArray
 
       def initialize(array, options)
-        super(array, options)
+        super(array, **options)
       end
 
       def limit(num)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      |no    
| BC breaks?        | no     
| Related Issue     | Fix #...  <!-- will close issue automatically, if any -->
| Need Doc update   |no


## Describe your change

Ruby 3.0 will not splat arguments on default

## What problem is this fixing?

wrong number of arguments (given 2, expected 0..1)