### PR TITLE
fix: only check current settings when indexing enabled

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -791,7 +791,7 @@ module AlgoliaSearch
 
       options[:check_settings] = true if options[:check_settings].nil?
 
-      current_settings = if options[:check_settings]
+      current_settings = if options[:check_settings] && !algolia_indexing_disabled?(options)
                            @algolia_indexes[settings].get_settings(:getVersion => 1) rescue nil # if the index doesn't exist
                          end
 

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -546,7 +546,7 @@ module AlgoliaSearch
         tmp_options.delete(:per_environment) # already included in the temporary index_name
         tmp_settings = settings.dup
 
-        if options[:check_settings] == false
+        if options[:check_settings] == false && master_settings != {}
           AlgoliaSearch.client.copy_index!(src_index_name, tmp_index_name, { scope: %w[settings synonyms rules] })
           tmp_index = SafeIndex.new(tmp_index_name, !!options[:raise_on_failure])
         else

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -533,6 +533,7 @@ module AlgoliaSearch
         # fetch the master settings
         master_index = algolia_ensure_init(options, settings)
         master_settings = master_index.get_settings rescue {} # if master doesn't exist yet
+        master_exists = master_settings != {}
         master_settings.merge!(JSON.parse(settings.to_settings.to_json)) # convert symbols to strings
 
         # remove the replicas of the temporary index
@@ -546,7 +547,7 @@ module AlgoliaSearch
         tmp_options.delete(:per_environment) # already included in the temporary index_name
         tmp_settings = settings.dup
 
-        if options[:check_settings] == false && master_settings != {}
+        if options[:check_settings] == false && master_exists
           AlgoliaSearch.client.copy_index!(src_index_name, tmp_index_name, { scope: %w[settings synonyms rules] })
           tmp_index = SafeIndex.new(tmp_index_name, !!options[:raise_on_failure])
         else

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -334,7 +334,7 @@ class SequelBook < Sequel::Model(SEQUEL_DB)
 
   include AlgoliaSearch
 
-  algoliasearch :synchronous => true, :index_name => safe_index_name("SequelBook"), :per_environment => true, :sanitize => true do
+  algoliasearch :synchronous => true, :index_name => safe_index_name("SequelBook"), :per_environment => true, :sanitize => true, :check_settings => true do
     add_attribute :test
     add_attribute :test2
 
@@ -369,6 +369,11 @@ end
 describe 'SequelBook' do
   before(:all) do
     SequelBook.clear_index!(true)
+  end
+
+  it 'should call get_settings' do
+    expect_any_instance_of(Algolia::Search::Index).to receive(:get_settings)
+    SequelBook.send(:algolia_ensure_init)
   end
 
   it "should index the book" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -177,7 +177,7 @@ end
 
 class Phone < ActiveRecord::Base
   include AlgoliaSearch
-  algoliasearch :check_settings => false do
+  algoliasearch :check_settings => false, :index_name => safe_index_name("Phone") do
   end
 end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -908,7 +908,6 @@ describe 'An imaginary store' do
     @products_in_database = Product.all
 
     Product.reindex(AlgoliaSearch::IndexSettings::DEFAULT_BATCH_SIZE, true)
-    sleep 5
   end
 
   it "should reindex with :check_settings set to false" do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -100,6 +100,9 @@ ActiveRecord::Schema.define do
   create_table :disabled_procs do |t|
     t.string :name
   end
+  create_table :disabled_indexings do |t|
+    t.string :name
+  end
   create_table :disabled_symbols do |t|
     t.string :name
   end
@@ -131,6 +134,13 @@ ActiveRecord::Schema.define do
       t.string :name
       t.string :skip
     end
+  end
+end
+
+class DisabledIndexing < ActiveRecord::Base
+  include AlgoliaSearch
+
+  algoliasearch :disable_indexing => true, :check_settings => true do
   end
 end
 
@@ -346,6 +356,13 @@ class SequelBook < Sequel::Model(SEQUEL_DB)
   private
   def public?
     released && !premium
+  end
+end
+
+describe 'DisabledIndexing' do
+  it 'should not call get_settings' do
+    expect_any_instance_of(Algolia::Search::Index).not_to receive(:get_settings)
+    DisabledIndexing.send(:algolia_ensure_init)
   end
 end
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | Fix #412 
| Need Doc update   | no


## Describe your change
This prevents a call to `get_settings` when indexing is disabled.