### PR TITLE
Fix issue with FrozenError around force_encoding

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -211,7 +211,7 @@ module AlgoliaSearch
     def encode_attributes(v)
       case v
       when String
-        v.force_encoding('utf-8')
+        v.dup.force_encoding('utf-8')
       when Hash
         v.each { |key, value| v[key] = encode_attributes(value) }
       when Array


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no 
| BC breaks?        | no     
| Related Issue     | none
| Need Doc update   | no


## Describe your change

After upgrading from Ruby 2.6.8 to 2.7.4, Algolia was throwing all kinds of errors when trying to index records.

The error was `FrozenError: can't modify frozen String: "User"`, and it was related to [this line](https://github.com/algolia/algoliasearch-rails/pull/418/files#diff-306cbaf0638b0091914db232c4cb2c9eeb376b19119786da3d1648b5c6185f3dL214) around `force_encoding` which was triggered because we had `force_utf8_encoding: true` in our [algolia_options](https://github.com/algolia/algoliasearch-rails#utf-8-encoding) on all models.