### PR TITLE
feat: allow to set client options

### DIFF
--- a/lib/algoliasearch/configuration.rb
+++ b/lib/algoliasearch/configuration.rb
@@ -15,6 +15,14 @@ module AlgoliaSearch
       )
     end
 
+    def client_opts
+      @@opts ||= {}
+    end
+
+    def client_opts=(opts)
+      @@opts = opts
+    end
+
     def client
       if @client.nil?
         setup_client
@@ -24,7 +32,7 @@ module AlgoliaSearch
     end
 
     def setup_client
-      @client = Algolia::Search::Client.create_with_config(Algolia::Search::Config.new(@@configuration))
+      @client = Algolia::Search::Client.new(Algolia::Search::Config.new(@@configuration), client_opts)
     end
   end
 end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | yes
| BC breaks?        | no     
| Related Issue     | Fix #417 
| Need Doc update   | yes

## Describe your change
This allows users to set `client_opts` on the configuration class, which will be forwarded to the Algolia client set up. This allows users to e.g. pass a custom logger to prevent the Algolia API client from using the default one, which writes to `debug.log`.