### PR TITLE
Fix ActiveJob::DeserializationError issue

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -399,7 +399,8 @@ module AlgoliaSearch
         raise ArgumentError.new("Cannot use a enqueue if the `synchronous` option if set") if options[:synchronous]
         proc = if options[:enqueue] == true
           Proc.new do |record, remove|
-            AlgoliaJob.perform_later(record, remove ? 'algolia_remove_from_index!' : 'algolia_index!')
+            record_or_object_id = remove ? algolia_object_id_of(record) : record
+            AlgoliaJob.perform_later(record.class.to_s, record_or_object_id, remove)
           end
         elsif options[:enqueue].respond_to?(:call)
           options[:enqueue]
@@ -623,7 +624,7 @@ module AlgoliaSearch
 
     def algolia_remove_from_index!(object, synchronous = false)
       return if algolia_without_auto_index_scope
-      object_id = algolia_object_id_of(object)
+      object_id = (object.is_a?(String) || object.is_a?(Numeric)) ? object : algolia_object_id_of(object)
       raise ArgumentError.new("Cannot index a record with a blank objectID") if object_id.blank?
       algolia_configurations.each do |options, settings|
         next if algolia_indexing_disabled?(options)

--- a/lib/algoliasearch/algolia_job.rb
+++ b/lib/algoliasearch/algolia_job.rb
@@ -2,8 +2,14 @@ module AlgoliaSearch
   class AlgoliaJob < ::ActiveJob::Base
     queue_as :algoliasearch
 
-    def perform(record, method)
-      record.send(method)
+    def perform(record_class, record_or_object_id, remove)
+      if remove
+        object_id = record_or_object_id
+        record_class.constantize.algolia_remove_from_index!(object_id)
+      else
+        record = record_or_object_id
+        record.algolia_index!
+      end
     end
   end
 end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | ??     
| Related Issue     | Fix #359
| Need Doc update   | no


## Describe your change

This is a different attempt at fixing the issue, following #369 being closed.
Change arguments passed to AlgoliaJob, so that we can run `algolia_remove_from_index!` correctly.
Change `algolia_remove_from_index!` so that if the object is a string or numeric, it's considered to be the object_id.

## What problem is this fixing?

When a record is removed and jobs are set to run async, an error happens: `ActiveJob::DeserializationError: Error while trying to deserialize arguments` - see #359
