### PR TITLE
fix:settings changes detection issue with empty array

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -847,6 +847,8 @@ module AlgoliaSearch
         if v.is_a?(Array) and prev_v.is_a?(Array)
           # compare array of strings, avoiding symbols VS strings comparison
           return true if v.map { |x| x.to_s } != prev_v.map { |x| x.to_s }
+        elsif v.blank? # blank? check is needed to compare [] and null
+          return true unless prev_v.blank?
         else
           return true if prev_v != v
         end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -597,6 +597,7 @@ describe 'Settings' do
     Color.send(:algoliasearch_settings_changed?, {}, {}).should == false
     Color.send(:algoliasearch_settings_changed?, {"searchableAttributes" => ["name"]}, {:searchableAttributes => ["name"]}).should == false
     Color.send(:algoliasearch_settings_changed?, {"searchableAttributes" => ["name"], "customRanking" => ["asc(hex)"]}, {"customRanking" => ["asc(hex)"]}).should == false
+    Color.send(:algoliasearch_settings_changed?, {"customRanking" => nil}, {"customRanking" => []}).should == false
   end
 
 end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | -
| Need Doc update   | no


## Describe your change

If you set customRanking as an empty Array, like below, Algolia understands that you set the customRanking as *null*.

```ruby
class Product < ActiveRecord::Base
  include AlgoliaSearch

  algoliasearch do
    customRanking [] # emptry Array
  end
end
```

As a result, the index setting API ( `/1/indexes/%s/settings?getVersion=1` ) returns setting information like below.
customRanking is nil.

```ruby
=> {
 "minWordSizefor1Typo"=>4,
 "minWordSizefor2Typos"=>8,
 "hitsPerPage"=>20,
 "maxValuesPerFacet"=>100,
 "version"=>1,
 # snip
 "customRanking"=>nil # API's response, raw JSON, is "customRanking":null
}
```

This behavior is natural and understandable.
However, the settings changes checking function does not handle this difference correctly.
So, I add an additional compare logic to the function, especially `[]` and `nil` comparing using `blank?` method.


## What problem is this fixing?

If you set customRanking ( or any other attributes ) as an empty Array , a useless index setting update API will be called when you use the search function.
It's heavy and blocking(synchronous) API calling, so your search function might be timed out.