### PR TITLE
fix: settings changes detection issue for replica indexes with inherit opt

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -789,6 +789,9 @@ module AlgoliaSearch
 
       index_settings ||= settings.to_settings
       index_settings = options[:primary_settings].to_settings.merge(index_settings) if options[:inherit]
+      replicas = index_settings.delete(:replicas) ||
+                 index_settings.delete('replicas')
+      index_settings[:replicas] = replicas unless replicas.nil? || options[:inherit]
 
       options[:check_settings] = true if options[:check_settings].nil?
 
@@ -797,9 +800,6 @@ module AlgoliaSearch
                          end
 
       if !algolia_indexing_disabled?(options) && options[:check_settings] && algoliasearch_settings_changed?(current_settings, index_settings)
-        replicas = index_settings.delete(:replicas) ||
-                   index_settings.delete('replicas')
-        index_settings[:replicas] = replicas unless replicas.nil? || options[:inherit]
         @algolia_indexes[settings].set_settings!(index_settings)
       end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1146,6 +1146,10 @@ describe "FowardToReplicas" do
         add_replica safe_index_name('ForwardToReplicas_replica') do
           attributesToHighlight %w(replica_highlight)
         end
+
+        add_replica safe_index_name('ForwardToReplicas_replica_inherited'), :inherit => true do
+          attributesToHighlight %w(replica_highlight)
+        end
       end
     end
   end
@@ -1184,6 +1188,10 @@ describe "FowardToReplicas" do
         add_replica safe_index_name('ForwardToReplicas_replica'), :inherit => true do
           attributesToHighlight %w(replica_highlight)
         end
+
+        add_replica safe_index_name('ForwardToReplicas_replica_inherited'), :inherit => true do
+          attributesToHighlight %w(replica_highlight)
+        end
       end
     end
 
@@ -1204,6 +1212,42 @@ describe "FowardToReplicas" do
     expect(replica_settings['attributesToHighlight']).to eq(%w(replica_highlight))
 
     expect(ForwardToReplicas.index.name).to eq(ForwardToReplicasTwo.index.name)
+  end
+
+  it "shouldn't update the replica settings if there is no change" do
+    Object.send(:remove_const, :ForwardToReplicasTwo) if Object.constants.include?(:ForwardToReplicasTwo)
+
+    class ForwardToReplicasTwo < ActiveRecord::Base
+      include AlgoliaSearch
+
+      algoliasearch :synchronous => true, :index_name => safe_index_name('ForwardToReplicas') do
+        attribute :name
+        searchableAttributes %w(first_value)
+        attributesToHighlight %w(primary_highlight)
+
+        add_replica safe_index_name('ForwardToReplicas_replica') do
+          attributesToHighlight %w(replica_highlight)
+        end
+
+        add_replica safe_index_name('ForwardToReplicas_replica_inherited'), :inherit => true do
+          attributesToHighlight %w(replica_highlight)
+        end
+      end
+    end
+
+    ForwardToReplicas.send :algolia_ensure_init
+
+    # Hacky way to hook replica settings update
+    ForwardToReplicas.create(:name => 'val')
+    ForwardToReplicas.reindex!
+
+    expect_any_instance_of(Algolia::Search::Index).not_to receive(:set_settings!)
+
+    ForwardToReplicasTwo.send :algolia_ensure_init
+
+    # Hacky way to hook replica settings update
+    ForwardToReplicasTwo.create(:name => 'val2')
+    ForwardToReplicasTwo.reindex!
   end
 end
 


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     | -
| Need Doc update   | no


## Describe your change

If you use `inherit` option for replica following [this document](https://github.com/algolia/algoliasearch-rails#primaryreplica), the settings changes check function ( `algoliasearch_settings_changed?` ) falsely detects the changes.
This function always detects that there is a change, even if there is no change.

The reason is simple.
The setting Hash building process, that should be done before the diff check process, is handled after the checking currently.
Therefore, when comparing replica index settings that use the `inherit` option, the comparison process is being performed with the `replicas` settings remaining that must be deleted in advance.
The replica index's settings do not include `replicas`.
It's available in the primary index's settings only, so it has not to be inherited.

So this PR move the process of removing the `replicas` settings from the replica index's settings to before the comparison logic.

## What problem is this fixing?

If you have a replica index with the `inherit` option, your app calls useless Algolia setting update API frequently.
It's heavy and blocking(synchronous) API calling, so your search function might be timed out.