### PR TITLE
Add relevancyStrictness to IndexSettings

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -54,7 +54,7 @@ module AlgoliaSearch
       # Attributes
       :searchableAttributes, :attributesForFaceting, :unretrievableAttributes, :attributesToRetrieve,
       # Ranking
-      :ranking, :customRanking, # Replicas are handled via `add_replica`
+      :ranking, :customRanking, :relevancyStrictness, # Replicas are handled via `add_replica`
       # Faceting
       :maxValuesPerFacet, :sortFacetValuesBy,
       # Highlighting / Snippeting


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related issue | -
| Need Doc update   |  no


## Describe your change

Add relevancyStrictness to IndexSettings which is used when configuring virtual replicas.

## What problem is this fixing?

Currently we cannot manage this attribute with the gem
