### PR TITLE
Allow `#algolia_dirty?` to be defined privately

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -746,7 +746,7 @@ module AlgoliaSearch
 
     def algolia_must_reindex?(object)
       # use +algolia_dirty?+ method if implemented
-      return object.send(:algolia_dirty?) if (object.respond_to?(:algolia_dirty?))
+      return object.send(:algolia_dirty?) if (object.respond_to?(:algolia_dirty?, true))
       # Loop over each index to see if a attribute used in records has changed
       algolia_configurations.each do |options, settings|
         next if algolia_indexing_disabled?(options)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -513,6 +513,8 @@ class Ebook < ActiveRecord::Base
     searchableAttributes ['name']
   end
 
+  private
+
   def algolia_dirty?
     return true if self.published_at.nil? || self.current_time.nil?
     # Consider dirty if published date is in the past


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | n/a
| Need Doc update   | no


## Describe your change

Include all methods when determining whether an object responds to `#algolia_dirty?`.

## What problem is this fixing?

`Object#send` can be used to call both public and private methods, but `Object#respond_to?` only returns `true` if the argument is a public method. This inconsistency is confusing.

To be more consistent, either `#send` should be replaced with `#public_send`, or `#respond_to` should have its optional `include_all` argument set to `true` (in this PR I opted for the latter).

There are many other places in the code that check if a method is defined publicly before calling it via `send` (checking if callbacks methods like `after_commit`, etc are defined). I can update those as well if wanted. But `#algolia_dirty?` seemed like the most critical, since that's the one end users would define themselves (rather than have defined by the framework they're using).