### PR TITLE
Allow configuring user agent / other default options

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## [Unreleased](https://github.com/algolia/algoliasearch-rails/compare/2.2.1...master)
+* Allow users to override default options, including user agent [`#438`](https://github.com/algolia/algoliasearch-rails/pull/438)
 
 ## [2.2.2](https://github.com/algolia/algoliasearch-rails/compare/2.2.2...2.3.0)
 ### Fixed

--- a/lib/algoliasearch/configuration.rb
+++ b/lib/algoliasearch/configuration.rb
@@ -1,5 +1,10 @@
 module AlgoliaSearch
   module Configuration
+    REQUIRED_CONFIGURATION = {
+      user_agent: "Algolia for Rails (#{AlgoliaSearch::VERSION}); Rails (#{Rails::VERSION::STRING})",
+      symbolize_keys: false
+    }
+
     def initialize
       @client = nil
     end
@@ -9,7 +14,11 @@ module AlgoliaSearch
     end
 
     def configuration=(configuration)
-      @@configuration = default_configuration.merge(configuration)
+      user_agent = [REQUIRED_CONFIGURATION[:user_agent], configuration[:append_to_user_agent]].compact.join('; ')
+      @@configuration = default_configuration
+                        .merge(configuration)
+                        .merge(REQUIRED_CONFIGURATION)
+                        .merge({ user_agent: user_agent })
     end
 
     def client_opts
@@ -33,10 +42,7 @@ module AlgoliaSearch
     end
 
     def default_configuration
-      {
-        user_agent: "Algolia for Rails (#{AlgoliaSearch::VERSION}); Rails (#{Rails::VERSION::STRING})",
-        symbolize_keys: false,
-      }
+      {}
     end
   end
 end

--- a/lib/algoliasearch/configuration.rb
+++ b/lib/algoliasearch/configuration.rb
@@ -9,10 +9,7 @@ module AlgoliaSearch
     end
 
     def configuration=(configuration)
-      @@configuration = configuration.merge(
-        :user_agent => "Algolia for Rails (#{AlgoliaSearch::VERSION}); Rails (#{Rails::VERSION::STRING})",
-        :symbolize_keys => false
-      )
+      @@configuration = default_configuration.merge(configuration)
     end
 
     def client_opts
@@ -33,6 +30,13 @@ module AlgoliaSearch
 
     def setup_client
       @client = Algolia::Search::Client.new(Algolia::Search::Config.new(@@configuration), client_opts)
+    end
+
+    def default_configuration
+      {
+        user_agent: "Algolia for Rails (#{AlgoliaSearch::VERSION}); Rails (#{Rails::VERSION::STRING})",
+        symbolize_keys: false,
+      }
     end
   end
 end


### PR DESCRIPTION

| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes (ish)
| New feature?      | yes (ish)
| BC breaks?        | yes (ish?)    
| Need Doc update   | yes

## Describe your change
Currently the default options are merged into the user-supplied configuration which means that any user supplied configuration for the user agent would be overwritten.

This could technically be described as a breaking change, but only if the user was relying on a somewhat odd behaviour. They'd have to set a configuration value then rely on it being overwritten. I can't think of a use case for that, but if someone was doing something interesting with a proxy that sniffs user-agent, and had done the above they might technically have a breakage. Otherwise, I'd usually describe this as a bugfix.

## What problem is this fixing?

This means users can supply a different user agent (if they so choose) but also other configuration options could be moved to have defaults that are then easily overridable by users.

