### PR TITLE
Allow configuration ActiveJob queue for auto_index

### DIFF
--- a/lib/algoliasearch/algolia_job.rb
+++ b/lib/algoliasearch/algolia_job.rb
@@ -1,6 +1,6 @@
 module AlgoliaSearch
   class AlgoliaJob < ::ActiveJob::Base
-    queue_as :algoliasearch
+    queue_as { AlgoliaSearch.configuration[:queue_name] }
 
     def perform(record, method)
       record.send(method)

--- a/lib/algoliasearch/configuration.rb
+++ b/lib/algoliasearch/configuration.rb
@@ -42,7 +42,9 @@ module AlgoliaSearch
     end
 
     def default_configuration
-      {}
+      {
+        queue_name: 'algoliasearch'
+      }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,8 @@ raise "missing ALGOLIA_APPLICATION_ID or ALGOLIA_API_KEY environment variables" 
 
 Thread.current[:algolia_hosts] = nil
 
+GlobalID.app = 'algoiasearch-rails'
+
 RSpec.configure do |c|
   c.mock_with :rspec
   c.filter_run :focus => true


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes
| BC breaks?        | no, provided #438 merged first / removed  
| Related Issue     | Makes progress towards https://github.com/algolia/algoliasearch-rails/issues/85
| Need Doc update   | yes


## Describe your change

Copy-pasted from commit message:
```
    Allow library users to specify default ActiveJob queue for indexing

    The current auto_indexing behaviours are great, but force a user to
    effectively reimplement the default enqueue behaviour if they just wanna
    use a different ActiveJob queue. Instead, allow the queue_name to
    specified as a configuraiton option, but fallback to the default if no
    value is set.

    Someone who just updates to a version with this commit should see no
    difference until they supply a value for the configuration, if they
    wish.
```