### PR TITLE
Fix issue with rules and synonyms loss during full reindex

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -547,12 +547,11 @@ module AlgoliaSearch
         tmp_options.delete(:per_environment) # already included in the temporary index_name
         tmp_settings = settings.dup
 
-        if options[:check_settings] == false && master_exists
+        if master_exists
           AlgoliaSearch.client.copy_index!(src_index_name, tmp_index_name, { scope: %w[settings synonyms rules] })
-          tmp_index = SafeIndex.new(tmp_index_name, !!options[:raise_on_failure])
-        else
-          tmp_index = algolia_ensure_init(tmp_options, tmp_settings, master_settings)
         end
+
+        tmp_index = SafeIndex.new(tmp_index_name, !!options[:raise_on_failure])
 
         algolia_find_in_batches(batch_size) do |group|
           if algolia_conditional_index?(options)


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| New feature?      | no
| BC breaks?        | no     
| Related Issue     | Fixes #268 
| Need Doc update   |no


## Describe your change
Instead of only copying the rules/synonyms when the `check_settings` option has been disabled, it will now always copy the data when the master index exists. I also removed the `algolia_ensure_init` because it seems like those checks are already kinda done at the top op the `algolia_reindex` method.

## What problem is this fixing?
Previously, when executing a full reindex with a temporary index in the AlgoliaSearch module, rules and synonyms were not copied over to the temporary index, resulting in data loss. This commit addresses the problem by ensuring that rules and synonyms are correctly copied from the source index to the temporary index during a full reindex.

