### PR TITLE
Add support for Pagy as pagination backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,5 +34,6 @@ end
 group :test, :development do
   gem 'will_paginate', '>= 2.3.15'
   gem 'kaminari', '< 1'
+  gem 'pagy'
 end
 

--- a/algoliasearch-rails.gemspec
+++ b/algoliasearch-rails.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
     "lib/algoliasearch/configuration.rb",
     "lib/algoliasearch/pagination.rb",
     "lib/algoliasearch/pagination/kaminari.rb",
+    "lib/algoliasearch/pagination/pagy.rb",
     "lib/algoliasearch/pagination/will_paginate.rb",
     "lib/algoliasearch/railtie.rb",
     "lib/algoliasearch/tasks/algoliasearch.rake",
@@ -81,6 +82,7 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<algolia>, ["< 3.0.0"])
       s.add_development_dependency(%q<will_paginate>, [">= 2.3.15"])
       s.add_development_dependency(%q<kaminari>, [">= 0"])
+      s.add_development_dependency(%q<pagy>, [">= 0"])
       s.add_development_dependency "rake"
       s.add_development_dependency "rdoc"
     else

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -683,7 +683,7 @@ module AlgoliaSearch
 
     def algolia_search(q, params = {})
       if AlgoliaSearch.configuration[:pagination_backend]
-        # kaminari and will_paginate start pagination at 1, Algolia starts at 0
+        # kaminari, will_paginate, and pagy start pagination at 1, Algolia starts at 0
         params[:page] = (params.delete('page') || params.delete(:page)).to_i
         params[:page] -= 1 if params[:page].to_i > 0
       end

--- a/lib/algoliasearch/pagination.rb
+++ b/lib/algoliasearch/pagination.rb
@@ -3,6 +3,7 @@ module AlgoliaSearch
 
     autoload :WillPaginate, 'algoliasearch/pagination/will_paginate'
     autoload :Kaminari, 'algoliasearch/pagination/kaminari'
+    autoload :Pagy, 'algoliasearch/pagination/pagy'
 
     def self.create(results, total_hits, options = {})
       return results if AlgoliaSearch.configuration[:pagination_backend].nil?

--- a/lib/algoliasearch/pagination/pagy.rb
+++ b/lib/algoliasearch/pagination/pagy.rb
@@ -1,15 +1,16 @@
 unless defined? Pagy
-  raise(AlgoliaSearch::BadConfiguration, "AlgoliaSearch: Please add 'pagy' to your Gemfile to use pagy_search pagination backend")
+  raise(AlgoliaSearch::BadConfiguration, "AlgoliaSearch: Please add 'pagy' to your Gemfile to use Pagy pagination backend")
 end
 
 module AlgoliaSearch
   module Pagination
     class Pagy
       def self.create(results, total_hits, options = {})
-        vars = {}
-        vars[:count] = total_hits
-        vars[:page] = options[:page]
-        vars[:items] = options[:per_page]
+        vars = {
+          count: total_hits,
+          page: options[:page],
+          items: options[:per_page]
+        }
 
         pagy = ::Pagy.new(vars)
         [pagy, results]

--- a/lib/algoliasearch/pagination/pagy.rb
+++ b/lib/algoliasearch/pagination/pagy.rb
@@ -1,0 +1,21 @@
+unless defined? Pagy
+  raise(AlgoliaSearch::BadConfiguration, "AlgoliaSearch: Please add 'pagy' to your Gemfile to use pagy_search pagination backend")
+end
+
+module AlgoliaSearch
+  module Pagination
+    class Pagy
+      def self.create(results, total_hits, options = {})
+        vars = {}
+        vars[:count] = total_hits
+        vars[:page] = options[:page]
+        vars[:items] = options[:per_page]
+
+        pagy = ::Pagy.new(vars)
+        [pagy, results]
+      end
+    end
+
+  end
+end
+

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1519,6 +1519,23 @@ describe 'Will_paginate' do
   end
 end
 
+describe 'Pagy' do
+  before(:all) do
+    require 'pagy'
+    AlgoliaSearch.configuration = { :application_id => ENV['ALGOLIA_APPLICATION_ID'], :api_key => ENV['ALGOLIA_API_KEY'], :pagination_backend => :pagy }
+  end
+
+  it "should paginate" do
+    pagy, cities = City.search '', :hitsPerPage => 2
+    pagy[:page].should eq(1)
+    pagy[:items].should eq(2)
+    pagy[:count].should eq(City.raw_search('')['nbHits'])
+    cities.length.should eq(2)
+    cities.should be_an(Array)
+  end
+end
+
+
 describe 'Disabled' do
   before(:all) do
     DisabledBoolean.index.clear_objects!

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1523,13 +1523,15 @@ describe 'Pagy' do
   before(:all) do
     require 'pagy'
     AlgoliaSearch.configuration = { :application_id => ENV['ALGOLIA_APPLICATION_ID'], :api_key => ENV['ALGOLIA_API_KEY'], :pagination_backend => :pagy }
+    City.create :name => 'San Francisco', :country => 'USA', :lat => 37.75, :lng => -122.68
+    City.create :name => 'Mountain View', :country => 'No man\'s land', :lat => 37.38, :lng => -122.08
   end
 
   it "should paginate" do
     pagy, cities = City.search '', :hitsPerPage => 2
-    pagy[:page].should eq(1)
-    pagy[:items].should eq(2)
-    pagy[:count].should eq(City.raw_search('')['nbHits'])
+    pagy.vars[:page].should eq(1)
+    pagy.vars[:items].should eq(2)
+    pagy.vars[:count].should eq(City.raw_search('')['nbHits'])
     cities.length.should eq(2)
     cities.should be_an(Array)
   end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1527,6 +1527,11 @@ describe 'Pagy' do
     City.create :name => 'Mountain View', :country => 'No man\'s land', :lat => 37.38, :lng => -122.08
   end
 
+  after(:all) do
+    # Reset the configuration to avoid conflicts with other tests
+    AlgoliaSearch.configuration = { :application_id => ENV['ALGOLIA_APPLICATION_ID'], :api_key => ENV['ALGOLIA_API_KEY'] }
+  end
+
   it "should paginate" do
     pagy, cities = City.search '', :hitsPerPage => 2
     pagy.page.should eq(1)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1529,9 +1529,9 @@ describe 'Pagy' do
 
   it "should paginate" do
     pagy, cities = City.search '', :hitsPerPage => 2
-    pagy.vars[:page].should eq(1)
-    pagy.vars[:items].should eq(2)
-    pagy.vars[:count].should eq(City.raw_search('')['nbHits'])
+    pagy.page.should eq(1)
+    pagy.items.should eq(2)
+    pagy.count.should eq(City.raw_search('')['nbHits'])
     cities.length.should eq(2)
     cities.should be_an(Array)
   end


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | no
| New feature?      | yes    <!-- please update the /CHANGELOG.md file -->
| BC breaks?        | no     
| Related Issue     |  https://github.com/algolia/algoliasearch-rails/issues/444 <!-- will close issue automatically, if any -->
| Need Doc update   | yes


## Describe your change

<!-- 
    Please describe your change, add as much detail as 
    necessary to understand your code.
-->
This change adds support for [pagy](https://github.com/ddnexus/pagy) as a pagination backend.

Co-authored by: [Ryan Wolfe](https://github.com/RyanJWolfe/RyanJWolfe)

## What problem is this fixing?

<!-- 
    Please include everything needed to understand the problem, 
    its context and consequences, and, if possible, how to recreate it.
-->
Currently when using algolia with pagy, we have to use pagy_array which means that we are pulling the entire result set for every page. This is not optimal.


### Here is a suggested addition to the README:

Even if we **highly recommend to perform all search (and therefore pagination) operations from your frontend using JavaScript**, 
we support the following as pagination backends:
[will_paginate](https://github.com/mislav/will_paginate) 
[kaminari](https://github.com/amatsuda/kaminari)
[pagy](https://github.com/ddnexus/pagy)

---
### pagy
To use <code>:pagy</code>, specify the <code>:pagination_backend</code> as follow:

```ruby
AlgoliaSearch.configuration = { application_id: 'YourApplicationID', api_key: 'YourAPI', pagination_backend: :pagy }
```

Then, as soon as you use the `search` method, the returning results will be a paginated set:

```ruby
# in your controller
@pagy, @posts = MyModel.search('foo', hitsPerPage: 10, page: params[:page] || 1)

# in your views
<%== pagy_nav(@pagy) %>
```
