### PR TITLE
Fixed atomic reindex to ensure init when check_settings=true.

### DIFF
--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -499,6 +499,8 @@ module AlgoliaSearch
             Algolia::Search::OperationIndexParams.new(operation: Algolia::Search::OperationType::COPY, destination: tmp_index_name, scope: %w[settings synonyms rules])
           ).task_id
           AlgoliaSearch.client.wait_for_task(index_name, task_id)
+        else
+          algolia_ensure_init(tmp_options, tmp_settings, master_settings)
         end
 
         algolia_find_in_batches(batch_size) do |group|


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | Probably yes
| New feature?      | Probably no
| BC breaks?        | Probably no     
| Related Issue     | 
| Need Doc update   | Probably no


## What problem is this fixing?

Atomic reindex (ex: `Product.reindex`) is always going to create tmp index with empty setting. And index move completed, previous settings disappeared. Not only specified settings inside algoliasearch block, but manual setting on dashboard.

#### How to Reproduce

`app/models/product.rb`

```
class Product < ApplicationRecord
  algoliasearch check_settings: true do
    attribute :title
    attribute :content
    attribute :updated_at_i
    
    customRanking ['desc(updated_at_i)']
    searchableAttributes ['title']
    indexLanguages ['ja']
  end
end
```

in rails console for instance

```
Product.reindex
  # Check dashboard, all specified settings are disappeared.
  # Not only specified settings inside algoliasearch block, but manual setting on dashboard.
```

## Describe your change

I understood the `check_settings` specification like this:  

When `check_settings: true` (default), all the index operation going under ActiveRecord respect the specified settings in algoliasearch block.  
On the other hand when `check_settings: false`, users just want to manage it on dashboard. So when new tmp index is to create, it just takes over the settings from existing index.

If my understanding is true, I guess current implementation accidentally missed `algolia_ensure_init` for tmp index when `check_settings=true`. I have imported that case from previous version below.

https://github.com/algolia/algoliasearch-rails/blob/9c1a0a46ca3dd4487cc3461c755a3fef144db491/lib/algoliasearch-rails.rb#L554C23-L554C86
