### PR TITLE
bugfix: avoid re initializing index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 gem 'json', '>= 1.5.1'
-gem 'algolia', '>= 3.5.2'
+gem 'algolia', '>= 3.12.0'
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
   gem 'rubysl', '~> 2.0', :platform => :rbx

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -769,10 +769,11 @@ module AlgoliaSearch
       options ||= algoliasearch_options
       settings ||= algoliasearch_settings
 
-      return if @algolia_indexes_init[settings]
-
       index_name = algolia_index_name(options)
 
+      return if @algolia_indexes_init[index_name]
+      
+      @algolia_indexes_init[index_name] = settings
 
       index_settings_hash ||= settings.to_settings.to_hash
       index_settings_hash = options[:primary_settings].to_settings.to_hash.merge(index_settings_hash) if options[:inherit]

--- a/lib/algoliasearch-rails.rb
+++ b/lib/algoliasearch-rails.rb
@@ -540,7 +540,7 @@ module AlgoliaSearch
 
         synonyms = s.delete("synonyms") || s.delete(:synonyms)
         unless synonyms.nil? || synonyms.empty?
-          resp = AlgoliaSearch.client.save_synonyms(index_name,synonyms.map {|s| Algolia::Search::SynonymHit.new({object_id: s.join("-"), synonyms: s, type: "synonym"}) } )
+          resp = AlgoliaSearch.client.save_synonyms(index_name,synonyms.map {|s| Algolia::Search::SynonymHit.new({algolia_object_id: s.join("-"), synonyms: s, type: "synonym"}) } )
           AlgoliaSearch.client.wait_for_task(index_name, resp.task_id) if synchronous || options[:synchronous]
         end
 
@@ -793,7 +793,7 @@ module AlgoliaSearch
 
         synonyms = s.delete("synonyms") || s.delete(:synonyms)
         unless synonyms.nil? || synonyms.empty?
-          resp = AlgoliaSearch.client.save_synonyms(index_name,synonyms.map {|s| Algolia::Search::SynonymHit.new({object_id: s.join("-"), synonyms: s, type: "synonym"}) } )
+          resp = AlgoliaSearch.client.save_synonyms(index_name,synonyms.map {|s| Algolia::Search::SynonymHit.new({algolia_object_id: s.join("-"), synonyms: s, type: "synonym"}) } )
           AlgoliaSearch.client.wait_for_task(index_name, resp.task_id) if options[:synchronous]
         end
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -451,11 +451,6 @@ describe 'SequelBook' do
     SequelBook.clear_index!(true)
   end
 
-  it 'should call get_settings' do
-    expect_any_instance_of(Algolia::SearchClient).to receive(:get_settings)
-    SequelBook.send(:algolia_ensure_init)
-  end
-
   it "should index the book" do
     @steve_jobs = SequelBook.create :name => 'Steve Jobs', :author => 'Walter Isaacson', :premium => true, :released => true
     results = SequelBook.search('steve')


### PR DESCRIPTION
| Q                 | A
| ----------------- | ----------
| Bug fix?          | yes
| BC breaks?        | no     
| Need Doc update |  no


## Describe your change

Re introduce variable check to avoid unecessary re initialization of already set indices.

in [v2 we used to have](https://github.com/algolia/algoliasearch-rails/blob/master/lib/algoliasearch-rails.rb#L774):

```ruby
     return @algolia_indexes[settings] if @algolia_indexes[settings]

      @algolia_indexes[settings] = SafeIndex.new(algolia_index_name(options), algoliasearch_options[:raise_on_failure])

      index_settings ||= settings.to_settings
      
      # proceed to get/set settings ... 
```

basically keeping track of indices that were already initialized in `@algolia_indexes`. For some reason [v3 is doing](https://github.com/algolia/algoliasearch-rails/blob/master/lib/algoliasearch-rails.rb#L767#L774):

```ruby
      @algolia_indexes_init ||= {}

      options ||= algoliasearch_options
      settings ||= algoliasearch_settings

      return if @algolia_indexes_init[settings]

      index_name = algolia_index_name(options)

     # proceed to get/set settings ...
```


setting that `@algolia_indexes_init` checking for previous initialization but never referecing it again so it will always re-set settings when calling the ensure_init method. 


This change actually stores the settings in the `@algolia_indexes_init` variable under the index name key and prevents the index to get re-set on every `ensure_init` method call.

## What problem is this fixing?

Get and Set settings operations being called on every single reindex operation on every index