### PR TITLE
add a test matrix for ruby 3.2,3.3,3.4 and rails 8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,3 +87,10 @@ workflows:
               version: ['3.0', '3.1']
               rails-version: ['7.0']
               sequel-version: ['5.0']
+      - test:
+          name: "Ruby << matrix.version >> - Rails << matrix.rails-version >>"
+          matrix:
+            parameters:
+              version: ['3.2', '3.3', '3.4']
+              rails-version: ['8.0']
+              sequel-version: ['5.0']

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
 
 This gem let you easily integrate the Algolia Search API to your favorite ORM. It's based on the [algoliasearch-client-ruby](https://github.com/algolia/algoliasearch-client-ruby) gem.
-Rails 6.x and 7.x are supported.
+Rails 6.x, 7.x and 8.x are supported.
 
 You might be interested in the sample Ruby on Rails application providing a `autocomplete.js`-based auto-completion and `InstantSearch.js`-based instant search results page: [algoliasearch-rails-example](https://github.com/algolia/algoliasearch-rails-example/).
 


### PR DESCRIPTION
| Q                            | A
| ------------------ | ----------
| Bug fix?                  | no
| New feature?          | no
| BC breaks?             | no     
| Related Issue          | N.A
| Need Doc update   | no

## Describe your change
This adds a test matrix for rails 8.0 with currently support ruby versions (3.2, 3.3, 3.4)

## What problem is this fixing?
Adds tested support for the latest versions of ruby and rails